### PR TITLE
Functional combinators & other utils for `Result`

### DIFF
--- a/core/shared/src/main/scala/result.scala
+++ b/core/shared/src/main/scala/result.scala
@@ -27,10 +27,10 @@ object Result {
   def catching[E <: Exception]: Catching[E] = new Catching[E]()
 
   /** Construct an answer. */
-  def answer[T, E <: Exception]: T => Result[T, E] = Answer(_)
+  def answer[T, E <: Exception](a : T): Result[T, E] = Answer(a)
 
   /** Construct an errata. */
-  def errata[T, E <: Exception]: E => Result[T, E] = Errata(_)
+  def errata[T, E <: Exception](e : E)(implicit cte : ClassTag[E]) = Errata(e)
 
 }
 
@@ -41,7 +41,7 @@ class Catching[E <: Exception]() {
   }
 }
 
-sealed class Result[+T, E <: Exception](val answer: T, val errors: Seq[(ClassTag[_], (String, Exception))],
+sealed abstract class Result[+T, +E <: Exception](val answer: T, val errors: Seq[(ClassTag[_], (String, Exception))],
     val unforeseen: Option[Throwable] = None) {
  
   def errata[E2 >: E: ClassTag]: Seq[E2] =
@@ -61,22 +61,22 @@ sealed class Result[+T, E <: Exception](val answer: T, val errors: Seq[(ClassTag
       val probs = res.errors ++ errors
       Result[T2, E with E2](res.get, probs)
     } catch {
-      case e: NullPointerException if !errors.isEmpty => Errata[T2, E with E2](errors)
+      case e: NullPointerException if errors.nonEmpty => Errata[T2, E with E2](errors)
       case e: Throwable => Unforeseen[T2, E with E2](e)
     }
 
   def map[T2](fn: T => T2) = Result[T2, E](fn(answer), errors)
 
-  def resolve[E2, T2 >: T](handlers: Each[E2, T2]*)(implicit ev: E2 <:< E): Resolved[T2, Nothing] = this match {
+  def resolve[E2, T2 >: T](handlers: Each[E2, T2]*): Resolved[T2, Nothing] = this match {
     case Unforeseen(e) =>
-      Unforeseen(e)
+      Unforeseen[T2, Nothing](e)
     case Answer(a) =>
-      Answer(a)
+      Answer[T2, Nothing](a)
     case Errata((t, (_, err)) +: _) =>
-      Answer(handlers.find { case Each(fn, ct) => ct == t }.get.fn(err.asInstanceOf[E2]))
+      Answer[T2, Nothing](handlers.find { case Each(fn, ct) => ct == t }.get.fn(err.asInstanceOf[E2]))
   }
 
-  def reconcile[E2, E3 <: Exception](handlers: Each[E2, E3]*)(implicit ev: E2 <:< E) = {
+  def reconcile[E2, E3 <: Exception](handlers: Each[E2, E3]*) = {
     val hs = handlers.map { case Each(e, typ) => typ -> e }.toMap[ClassTag[_], E2 => E3]
     errors.map { case (t, (p, e)) => hs(t)(e.asInstanceOf[E2]) }
   }
@@ -103,10 +103,11 @@ sealed class Result[+T, E <: Exception](val answer: T, val errors: Seq[(ClassTag
     }
 
   /** Catamorphism. Run the first given function if answer, otherwise, the second given function over the errata. */
-  def fold[X](l: T => X, r: Seq[E] => X): X =
+  def fold[X](l: T => X, r: Seq[(ClassTag[_], (String, Exception))] => X): X =
     this match {
       case Answer(a) => l(a)
-      case Errata(_) => r(errata)
+      case Errata(e) => r(e)
+      case Unforeseen(e) => throw e
     }
 
   /** Return `true` if this result is an answer satisfying the given predicate. */
@@ -145,10 +146,10 @@ sealed class Result[+T, E <: Exception](val answer: T, val errors: Seq[(ClassTag
     }
 
   /** Convert to a core `scala.Either` at your own peril. blows up if an unforeseen exception is found */
-  def toEither: Either[Seq[E], T] =
+  def toEither: Either[Seq[(ClassTag[_], (String, Exception))], T] =
     this match {
       case Answer(b) => Right(b)
-      case Errata(a) => Left(errata)
+      case Errata(a) => Left(a)
       case Unforeseen(e) => throw e
     }
 
@@ -164,10 +165,10 @@ sealed class Result[+T, E <: Exception](val answer: T, val errors: Seq[(ClassTag
     getOrElse(x)
 
   /** Return the answer of this result or run the given function on the errata. */
-  def valueOr[BB >: T](x: Seq[E] => BB): BB =
+  def valueOr[BB >: T](x: Seq[(ClassTag[_], (String, Exception))] => BB): BB =
     this match {
       case Answer(b) => b
-      case Errata(a) => x(errata)
+      case Errata(a) => x(a)
       case Unforeseen(e) => throw e
     }
 
@@ -179,7 +180,7 @@ object Resolved {
 
   def apply[T, E <: Exception](answer: T, unforeseen: Option[E]) = if(unforeseen.isEmpty) Answer(answer) else Unforeseen(unforeseen.get)
 }
-sealed class Resolved[+T, E <: Exception](answer: T, unforeseen: Option[Throwable])
+sealed abstract class Resolved[+T, E <: Exception](answer: T, unforeseen: Option[Throwable])
     extends Result[T, E](answer, Seq(), unforeseen) {
 
   override def equals(that: Any) = that match {
@@ -198,20 +199,26 @@ case class Errata[T, E <: Exception](override val errors: Seq[(ClassTag[_], (Str
   override def toString = "Errata(\n"+ errors.map { case (t, (p, e)) => s"$t: ${e.getMessage} [$p]" } +"\n)"
 }
 
+object Errata {
+
+  def apply[T, E <: Exception](e: => E)
+      (implicit classTag: ClassTag[E]): Result[T, E] = Errata(Vector((?[ClassTag[E]], ("", e))))
+}
+
 case class Unforeseen[T, E <: Exception](e: Throwable) extends Resolved[T, E](null.asInstanceOf[T], Some(e))
 
 case class AbortException() extends Exception
 
 private[core] class ReturnResultMode[+Group <: MethodConstraint] extends Mode[Group] {
-  type Wrap[+R, E <: Exception] = Result[R, E]
+  type Wrap[+R, +E <: Exception] = Result[R, E]
   
   def wrap[R, E <: Exception](blk: => R): Result[R, E] = {
     try {
       val res = blk
-      Result(res, accumulated)
+      Result[R, E](res, accumulated)
     } catch {
       case AbortException() =>
-        Result(null.asInstanceOf[R], accumulated)
+        Result[R, E](null.asInstanceOf[R], accumulated)
       case e: Throwable =>
         if(accumulated.isEmpty) Unforeseen[R, E](e)
         else Errata(accumulated)

--- a/core/shared/src/main/scala/result.scala
+++ b/core/shared/src/main/scala/result.scala
@@ -12,11 +12,9 @@
 \******************************************************************************************************************/
 package rapture.core
 
-import scala.reflect._
+import scala.language.existentials
+import scala.language.experimental.macros
 import scala.reflect.ClassTag
-
-import language.experimental.macros
-import language.existentials
 
 object Result {
   private[core] def apply[T, E <: Exception](result: => T, errors: Seq[(ClassTag[_], (String, Exception))]) = try {

--- a/core/shared/src/main/scala/result.scala
+++ b/core/shared/src/main/scala/result.scala
@@ -27,10 +27,10 @@ object Result {
   def catching[E <: Exception]: Catching[E] = new Catching[E]()
 
   /** Construct an answer. */
-  def answer[T, E <: Exception](a : T): Result[T, E] = Answer(a)
+  def answer[T, E <: Exception](a : T): Result[T, E] = Answer[T, E](a)
 
   /** Construct an errata. */
-  def errata[T, E <: Exception](e : E)(implicit cte : ClassTag[E]) = Errata(e)
+  def errata[T, E <: Exception](e : E)(implicit cte : ClassTag[E]) = Errata[T, E](e)
 
 }
 

--- a/core/shared/src/main/scala/result.scala
+++ b/core/shared/src/main/scala/result.scala
@@ -154,18 +154,18 @@ sealed abstract class Result[+T, +E <: Exception](val answer: T, val errors: Seq
     }
 
   /** Return the answer of this result or the given default if errata. Alias for `|` */
-  def getOrElse[BB >: T](x: => BB): BB =
+  def getOrElse[TT >: T](x: => TT): TT =
     this match {
       case Answer(b) => b
       case _ => x
     }
 
   /** Return the answer value of this result or the given default if errata. Alias for `getOrElse` */
-  def |[BB >: T](x: => BB): BB =
+  def |[TT >: T](x: => TT): TT =
     getOrElse(x)
 
   /** Return the answer of this result or run the given function on the errata. */
-  def valueOr[BB >: T](x: Seq[(ClassTag[_], (String, Exception))] => BB): BB =
+  def valueOr[TT >: T](x: Seq[(ClassTag[_], (String, Exception))] => TT): TT =
     this match {
       case Answer(b) => b
       case Errata(a) => x(a)

--- a/core/test/src/tests.scala
+++ b/core/test/src/tests.scala
@@ -95,5 +95,130 @@ object Tests extends TestSuite {
       throw BetaException()
     }
   } returns Unforeseen(BetaException())
+
+  val `Checking isErrata with errata` = test {
+    Result.errata(AlphaException()).isErrata
+  } returns true
+
+  val `Checking isErrata with answer` = test {
+    Result.answer(1).isErrata
+  } returns false
+
+  val `Checking isAnswer with errata` = test {
+    Result.errata(AlphaException()).isAnswer
+  } returns false
+
+  val `Checking isAnswer with answer` = test {
+    Result.answer(1).isAnswer
+  } returns true
+
+  val `Checking isUnforeseen with answer` = test {
+    Result.answer(1).isUnforeseen
+  } returns false
+
+  val `Checking isUnforeseen with errata` = test {
+    Result.errata(AlphaException()).isUnforeseen
+  } returns false
+
+  val `Checking isUnforeseen with unforeseen` = test {
+    Result.catching[AlphaException] {
+      throw BetaException()
+    }.isUnforeseen
+  } returns true
+
+  val `Fold answer` = test {
+    Result.answer(1).fold(
+      a => a + 1,
+      e => 0
+    )
+  } returns 2
+
+  val `Fold errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).fold(
+      a => a + 1,
+      e => 0
+    )
+  } returns 0
+
+  val `Exists answer` = test {
+    Result.answer(1).exists(_ == 1)
+  } returns true
+
+  val `Exists answer none found` = test {
+    Result.answer(1).exists(_ == 0)
+  } returns false
+
+  val `Exists errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).exists(_ == 1)
+  } returns false
+
+  val `Forall answer` = test {
+    Result.answer(1).forall(_ == 1)
+  } returns true
+
+  val `Forall answer none found` = test {
+    Result.answer(1).forall(_ == 0)
+  } returns false
+
+  val `Forall errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).forall(_ == 1)
+  } returns true
+
+  val `toList answer` = test {
+    Result.answer(1).toList
+  } returns List(1)
+
+  val `toList errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toList
+  } returns Nil
+
+  val `toStream answer` = test {
+    Result.answer(1).toStream
+  } returns Stream(1)
+
+  val `toStream errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toStream
+  } returns Stream.empty[Int]
+
+  val `toOption answer` = test {
+    Result.answer(1).toOption
+  } returns Some(1)
+
+  val `toOption errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toOption
+  } returns None
+
+  val `toEither answer` = test {
+    Result.answer(1).toEither
+  } returns Right(1)
+
+  val `toEither errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toEither
+  } returns Left(Seq(AlphaException()))
+
+  val `getOrElse answer` = test {
+    Result.answer(1).getOrElse(0)
+  } returns 1
+
+  val `getOrElse errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).getOrElse(0)
+  } returns 0
+
+  val `| answer` = test {
+    Result.answer(1) | 0
+  } returns 1
+
+  val `| errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()) | 0
+  } returns 0
+
+  val `valueOr answer` = test {
+    Result.answer(1).valueOr(_ => 0)
+  } returns 1
+
+  val `valueOr errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).valueOr(_ => 0)
+  } returns 0
+
 }
 

--- a/core/test/src/tests.scala
+++ b/core/test/src/tests.scala
@@ -194,7 +194,7 @@ object Tests extends TestSuite {
 
   val `toEither errata` = test {
     Result.errata[Int, AlphaException](AlphaException()).toEither
-  } returns Left(Seq(AlphaException()))
+  } satisfies (v => v.isLeft)
 
   val `getOrElse answer` = test {
     Result.answer(1).getOrElse(0)


### PR DESCRIPTION
This PR aims to bring some of the combinators and utility methods I have been missing in `Result`.
Among others...

```
isErrata
isAnswer
isUnforeseen
fold
exists
forall
toList
toStream
toOption
toEither
getOrElse
valueOr
```

More to come in the Scalaz integration with `ResultT`, monoid and applicative instances, etc...

@propensive can you please review? Thanks!
