### PR TITLE
Fixing compilation errors on mac

### DIFF
--- a/cli/shared/src/main/scala/cli.scala
+++ b/cli/shared/src/main/scala/cli.scala
@@ -23,7 +23,7 @@ import rapture.log._
 import annotation.tailrec
 
 import encodings.system._
-import logLevel.trace._
+import logLevels.trace._
 
 import scala.collection.immutable.ListMap
 

--- a/core-scalaz/shared/src/main/scala/modes.scala
+++ b/core-scalaz/shared/src/main/scala/modes.scala
@@ -23,7 +23,7 @@ import scalaz.concurrent._
 
 object `package` {
 
-  implicit class ScalazExplicits[+T, E <: Exception](explicit: modes.Explicit[T, E]) {
+  implicit class ScalazExplicits[+T, E <: Exception](explicit: modes.Explicitly[T, E]) {
     def task(implicit pool: ExecutorService): Task[T] = returnTasks.wrap(explicit.get)
     def validation: Validation[E, T] = returnValidations.wrap(explicit.get)
   }

--- a/core/shared/src/main/scala/modes.scala
+++ b/core/shared/src/main/scala/modes.scala
@@ -164,7 +164,7 @@ package modes {
     def apply[D: TimeSystem.ByDuration, G <: MethodConstraint] = modeImplicit[D, G]
   }
 
-  class Explicit[+Res, E <: Exception](blk: => Res) {
+  class Explicitly[+Res, E <: Exception](blk: => Res) {
     def get: Res = blk
     def opt: Option[Res] = returnOption[Nothing].wrap(blk)
     def getOrElse[Res2 >: Res](t: Res2): Res2 = opt.getOrElse(blk)
@@ -192,10 +192,10 @@ private[core] class ThrowExceptionsMode[+G <: MethodConstraint] extends Mode[G] 
 }
 
 private[core] class ExplicitMode[+G <: MethodConstraint] extends Mode[G] {
-  type Wrap[+T, E <: Exception] = modes.Explicit[T, E]
-  
-  def wrap[T, E <: Exception](t: => T): modes.Explicit[T, E] =
-    new modes.Explicit[T, E](t)
+  type Wrap[+T, E <: Exception] = modes.Explicitly[T, E]
+
+  def wrap[T, E <: Exception](t: => T): modes.Explicitly[T, E] =
+    new modes.Explicitly[T, E](t)
   
   def unwrap[Return](value: => Wrap[Return, _ <: Exception]): Return = value.get
 }

--- a/log/shared/src/main/scala/levels.scala
+++ b/log/shared/src/main/scala/levels.scala
@@ -20,7 +20,7 @@ trait Warn extends Info
 trait Error extends Warn
 trait Fatal extends Error
 
-object logLevel {
+object logLevels {
   
   object trace {
     implicit val logLevelImplicit: NamedLogAction = new NamedLogAction(0, "trace")

--- a/log/shared/src/main/scala/log.scala
+++ b/log/shared/src/main/scala/log.scala
@@ -51,7 +51,7 @@ object LogAction {
     new LogAction { def level = -1 }
 }
 
-@implicitNotFound("You have not specified a valid logging level. Please import one of logLevel"+
+@implicitNotFound("You have not specified a valid logging level. Please import one of logLevels"+
     ".{trace._, debug._, info._, warn._, error._, fatal._}.")
 trait LogAction {
   def level: Int
@@ -124,7 +124,7 @@ abstract class Spec {
 }
 
 /*object Main extends App {
-  import logLevel.debug._
+  import logLevels.debug._
   import encodings.system
   implicit val output = Logger(Stdout)
   implicit val spec = log"  "


### PR DESCRIPTION
Renames `logLevel` -> `logLevels` and `class Explicit` to `class Explicitly` in order to avoid naming collisions on Mac when compiling all modules.

@propensive ready for review. thanks!
