### PR TITLE
ResultT transformer

### DIFF
--- a/core-scalaz/shared/src/main/scala/ResultT.scala
+++ b/core-scalaz/shared/src/main/scala/ResultT.scala
@@ -1,0 +1,65 @@
+package rapture.core.scalazResult
+
+
+import rapture.core.{Errata, NotMatchingFilter, Result}
+
+import scala.language.{higherKinds, reflectiveCalls}
+import scala.reflect.ClassTag
+import scalaz.{Functor, _}
+
+/**
+ * ResultT monad transformer
+ *
+ * Represents a computation of type `Result[A,B]`.
+ *
+ * Example:
+ * {{{
+ * val x: Option[Result[String, E]] = Some(Answer(1))
+ * ResultT(x).map(1+).run // Some(Answer(2))
+ * }}}
+ **/
+sealed trait ResultT[F[+ _], +T, E <: Exception] {
+
+  val run: F[Result[T, E]]
+
+  /** Map on the answer of this result. */
+  def map[C](f: T => C)(implicit F: Functor[F], cte : ClassTag[E]): ResultT[F, C, E] =
+    ResultT(F.map(run)(_.map(f)))
+
+  /** Bind through the answer of this result. */
+  def flatMap[C](f: T => ResultT[F, C, E])(implicit F: Monad[F], cte : ClassTag[E]): ResultT[F, C, E] =
+    ResultT[F, C, E](F.bind(run)(_.fold(a => f(a).run, b => F.point(Errata[C, E](b)))))
+
+  /** Filter on the answer of this result. */
+  def filter(p: T => Boolean)(implicit F: Functor[F], cte : ClassTag[E]): ResultT[F, T, E with NotMatchingFilter] =
+    ResultT(F.map(run)(_.filter(p)))
+
+  /** Alias for `filter`.
+    * @since 7.0.2
+    */
+  def withFilter(p: T => Boolean)(implicit F: Functor[F], cte : ClassTag[E]): ResultT[F, T, E with NotMatchingFilter] =
+    filter(p)
+
+}
+
+object ResultT extends ResultTFunctions {
+  /** Construct a result value. */
+  def apply[F[+ _], T, E <: Exception : ClassTag](a: F[Result[T, E]]): ResultT[F, T, E] =
+    resultT[F, T, E](a)
+
+  /** Construct an answer value. */
+  def answer[F[+ _], T, E <: Exception : ClassTag](a: F[T])(implicit F: Functor[F]): ResultT[F, T, E] =
+    apply[F, T, E](F.map(a)(Result.answer[T, E]))
+
+  /** Construct an errata value. */
+  def errata[F[+ _], T, E <: Exception : ClassTag](a: F[E])(implicit F: Functor[F]): ResultT[F, T, E] =
+    apply[F, T, E](F.map(a)(Result.errata[T, E]))
+
+}
+
+private[scalazResult] trait ResultTFunctions {
+  def resultT[F[+ _], T, E <: Exception](a: F[Result[T, E]]): ResultT[F, T, E] = new ResultT[F, T, E] {
+    val run = a
+  }
+}
+

--- a/core-scalaz/shared/src/test/scala/Tests.scala
+++ b/core-scalaz/shared/src/test/scala/Tests.scala
@@ -1,8 +1,13 @@
-package rapture.core.test
+package rapture.core.scalazResult.test
 
 import rapture.core._
-import rapture.core.test.Tests._
+import rapture.core.scalazResult.test.Tests._
+import rapture.test.TestSuite
+import rapture.core._
+import rapture.core.scalazResult.ResultT
 import rapture.test._
+import scalaz._
+import Scalaz._
 
 object Tests extends TestSuite {
 
@@ -10,244 +15,49 @@ object Tests extends TestSuite {
   case class BetaException() extends Exception
   case class MiscException() extends Exception
 
-  def alpha(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, AlphaException] = mode.wrap {
-    if(x == 0) mode.exception(AlphaException())
-    else if(x == 1) throw MiscException()
-    else 0
-  }
-
-  def beta(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, BetaException] = mode.wrap {
-    if(x == 0) mode.exception(BetaException())
-    else if(x == 1) throw MiscException()
-    else 0
-  }
-
-  val `Successful Result` = test {
-    import modes.returnResult._
-    alpha(2)
-  } returns Answer(0)
-
-  val `Unforeseen Result` = test {
-    import modes.returnResult._
-    alpha(1)
-  } returns Unforeseen(MiscException())
-
-  val `Expected error Result` = test {
-    import modes.returnResult._
-    alpha(0)
-  } satisfies { case Errata(_) => true case _ => false }
-
-  val `FlatMapped Successful Result` = test {
-    import modes.returnResult._
-    for {
-      a <- alpha(2)
-      b <- beta(2)
-    } yield a + b
-  } returns Answer(0)
-
-  val `FlatMapped first fails` = test {
-    import modes.returnResult._
-    for {
-      a <- alpha(0)
-      b <- beta(2)
-    } yield a + b
-  } satisfies (_.exceptions == Vector(AlphaException()))
-
-  val `FlatMapped second fails` = test {
-    import modes.returnResult._
-    for {
-      a <- alpha(2)
-      b <- beta(0)
-    } yield a + b
-  } satisfies (_.exceptions == Vector(BetaException()))
-
-  val `Resolving errata 1` = test {
-    import modes.returnResult._
-    val result = for(a <- alpha(2); b <- beta(0)) yield a + b
-    result.resolve(
-      each[AlphaException] { e => 10 },
-      each[BetaException] { e => 20 }
-    )
-  } returns Answer(20)
-
-  val `Resolving errata 2` = test {
-    import modes.returnResult._
-    val result = for(a <- alpha(0); b <- beta(2)) yield a + b
-    result.resolve(
-      each[AlphaException] { e => 10 },
-      each[BetaException] { e => 20 }
-    )
-  } returns Answer(10)
-
-  val `Catching success` = test {
-    Result.catching[AlphaException] {
-      "success"
-    }
-  } returns Answer("success")
-
-  val `Catching failure` = test {
-    Result.catching[AlphaException] {
-      throw AlphaException()
-    }
-  } satisfies (_.exceptions == Vector(AlphaException()))
-
-  val `Catching unforeseen` = test {
-    Result.catching[AlphaException] {
-      throw BetaException()
-    }
-  } returns Unforeseen(BetaException())
-
   val `Checking isErrata with errata` = test {
-    Result.errata(AlphaException()).isErrata
+    ResultT.errata(Option(AlphaException())).run.get.isErrata
   } returns true
 
   val `Checking isErrata with answer` = test {
-    Result.answer(1).isErrata
+    ResultT.answer(Option(1)).run.get.isErrata
   } returns false
 
   val `Checking isAnswer with errata` = test {
-    Result.errata(AlphaException()).isAnswer
+    ResultT.errata(Option(AlphaException())).run.get.isAnswer
   } returns false
 
   val `Checking isAnswer with answer` = test {
-    Result.answer(1).isAnswer
+    ResultT.answer(Option(1)).run.get.isAnswer
   } returns true
 
   val `Checking isUnforeseen with answer` = test {
-    Result.answer(1).isUnforeseen
+    ResultT.answer(Option(1)).run.get.isUnforeseen
   } returns false
 
   val `Checking isUnforeseen with errata` = test {
-    Result.errata(AlphaException()).isUnforeseen
+    ResultT.errata(Option(AlphaException())).run.get.isUnforeseen
   } returns false
-
-  val `Checking isUnforeseen with unforeseen` = test {
-    Result.catching[AlphaException] {
-      throw BetaException()
-    }.isUnforeseen
-  } returns true
-
-  val `Fold answer` = test {
-    Result.answer(1).fold(
-      a => a + 1,
-      e => 0
-    )
-  } returns 2
-
-  val `Fold errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).fold(
-      a => a + 1,
-      e => 0
-    )
-  } returns 0
-
-  val `Exists answer` = test {
-    Result.answer(1).exists(_ == 1)
-  } returns true
-
-  val `Exists answer none found` = test {
-    Result.answer(1).exists(_ == 0)
-  } returns false
-
-  val `Exists errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).exists(_ == 1)
-  } returns false
-
-  val `Forall answer` = test {
-    Result.answer(1).forall(_ == 1)
-  } returns true
-
-  val `Forall answer none found` = test {
-    Result.answer(1).forall(_ == 0)
-  } returns false
-
-  val `Forall errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).forall(_ == 1)
-  } returns true
-
-  val `toList answer` = test {
-    Result.answer(1).to[List]
-  } returns List(1)
-
-  val `toList errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).to[List]
-  } returns Nil
-
-  val `toStream answer` = test {
-    Result.answer(1).to[Stream]
-  } returns Stream(1)
-
-  val `toStream errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).to[Stream]
-  } returns Stream.empty[Int]
-
-  val `toOption answer` = test {
-    Result.answer(1).toOption
-  } returns Some(1)
-
-  val `toOption errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).toOption
-  } returns None
-
-  val `toEither answer` = test {
-    Result.answer(1).toEither
-  } returns Right(1)
-
-  val `toEither errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).toEither
-  } satisfies (v => v.isLeft)
-
-  val `getOrElse answer` = test {
-    Result.answer(1).getOrElse(0)
-  } returns 1
-
-  val `getOrElse errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).getOrElse(0)
-  } returns 0
-
-  val `| answer` = test {
-    Result.answer(1) | 0
-  } returns 1
-
-  val `| errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()) | 0
-  } returns 0
-
-  val `valueOr answer` = test {
-    Result.answer(1).valueOr(_ => 0)
-  } returns 1
-
-  val `valueOr errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).valueOr(_ => 0)
-  } returns 0
 
   val `filter answer` = test {
-    Result.answer(1) filter (_ == 1)
-  } returns Answer(1)
-
-  val `filter answer` = test {
-    Result.answer(1) filter (_ == 0)
-  } returns Errata(Nil)
-
-  val `filter errata` = test {
-    Errata[String, Nothing](Nil) filter (_.isEmpty)
-  } returns Errata(Nil)
+    ResultT.answer(Option(1)) filter (_ == 1)
+  } returns ResultT(Some(Answer(1)))
 
   val `withFilter errata monadic` = test {
     for {
-      x <- Answer(1)
+      x <- Option(Answer(1)) |> ResultT.apply
       if x == 0
       y = x + 1
     } yield y
-  } returns Errata(Nil)
+  } returns ResultT(Some(Errata(Nil)))
 
   val `withFilter answer monadic` = test {
     for {
-      x <- Answer(1)
+      x <- Option(Answer(1)) |> ResultT.apply
       if x == 1
       y = x + 1
     } yield y
-  } returns Answer(2)
+  } returns ResultT(Some(Answer(2)))
 
 }
 

--- a/core-scalaz/shared/src/test/scala/Tests.scala
+++ b/core-scalaz/shared/src/test/scala/Tests.scala
@@ -1,0 +1,253 @@
+package rapture.core.test
+
+import rapture.core._
+import rapture.core.test.Tests._
+import rapture.test._
+
+object Tests extends TestSuite {
+
+  case class AlphaException() extends Exception
+  case class BetaException() extends Exception
+  case class MiscException() extends Exception
+
+  def alpha(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, AlphaException] = mode.wrap {
+    if(x == 0) mode.exception(AlphaException())
+    else if(x == 1) throw MiscException()
+    else 0
+  }
+
+  def beta(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, BetaException] = mode.wrap {
+    if(x == 0) mode.exception(BetaException())
+    else if(x == 1) throw MiscException()
+    else 0
+  }
+
+  val `Successful Result` = test {
+    import modes.returnResult._
+    alpha(2)
+  } returns Answer(0)
+
+  val `Unforeseen Result` = test {
+    import modes.returnResult._
+    alpha(1)
+  } returns Unforeseen(MiscException())
+
+  val `Expected error Result` = test {
+    import modes.returnResult._
+    alpha(0)
+  } satisfies { case Errata(_) => true case _ => false }
+
+  val `FlatMapped Successful Result` = test {
+    import modes.returnResult._
+    for {
+      a <- alpha(2)
+      b <- beta(2)
+    } yield a + b
+  } returns Answer(0)
+
+  val `FlatMapped first fails` = test {
+    import modes.returnResult._
+    for {
+      a <- alpha(0)
+      b <- beta(2)
+    } yield a + b
+  } satisfies (_.exceptions == Vector(AlphaException()))
+
+  val `FlatMapped second fails` = test {
+    import modes.returnResult._
+    for {
+      a <- alpha(2)
+      b <- beta(0)
+    } yield a + b
+  } satisfies (_.exceptions == Vector(BetaException()))
+
+  val `Resolving errata 1` = test {
+    import modes.returnResult._
+    val result = for(a <- alpha(2); b <- beta(0)) yield a + b
+    result.resolve(
+      each[AlphaException] { e => 10 },
+      each[BetaException] { e => 20 }
+    )
+  } returns Answer(20)
+
+  val `Resolving errata 2` = test {
+    import modes.returnResult._
+    val result = for(a <- alpha(0); b <- beta(2)) yield a + b
+    result.resolve(
+      each[AlphaException] { e => 10 },
+      each[BetaException] { e => 20 }
+    )
+  } returns Answer(10)
+
+  val `Catching success` = test {
+    Result.catching[AlphaException] {
+      "success"
+    }
+  } returns Answer("success")
+
+  val `Catching failure` = test {
+    Result.catching[AlphaException] {
+      throw AlphaException()
+    }
+  } satisfies (_.exceptions == Vector(AlphaException()))
+
+  val `Catching unforeseen` = test {
+    Result.catching[AlphaException] {
+      throw BetaException()
+    }
+  } returns Unforeseen(BetaException())
+
+  val `Checking isErrata with errata` = test {
+    Result.errata(AlphaException()).isErrata
+  } returns true
+
+  val `Checking isErrata with answer` = test {
+    Result.answer(1).isErrata
+  } returns false
+
+  val `Checking isAnswer with errata` = test {
+    Result.errata(AlphaException()).isAnswer
+  } returns false
+
+  val `Checking isAnswer with answer` = test {
+    Result.answer(1).isAnswer
+  } returns true
+
+  val `Checking isUnforeseen with answer` = test {
+    Result.answer(1).isUnforeseen
+  } returns false
+
+  val `Checking isUnforeseen with errata` = test {
+    Result.errata(AlphaException()).isUnforeseen
+  } returns false
+
+  val `Checking isUnforeseen with unforeseen` = test {
+    Result.catching[AlphaException] {
+      throw BetaException()
+    }.isUnforeseen
+  } returns true
+
+  val `Fold answer` = test {
+    Result.answer(1).fold(
+      a => a + 1,
+      e => 0
+    )
+  } returns 2
+
+  val `Fold errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).fold(
+      a => a + 1,
+      e => 0
+    )
+  } returns 0
+
+  val `Exists answer` = test {
+    Result.answer(1).exists(_ == 1)
+  } returns true
+
+  val `Exists answer none found` = test {
+    Result.answer(1).exists(_ == 0)
+  } returns false
+
+  val `Exists errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).exists(_ == 1)
+  } returns false
+
+  val `Forall answer` = test {
+    Result.answer(1).forall(_ == 1)
+  } returns true
+
+  val `Forall answer none found` = test {
+    Result.answer(1).forall(_ == 0)
+  } returns false
+
+  val `Forall errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).forall(_ == 1)
+  } returns true
+
+  val `toList answer` = test {
+    Result.answer(1).to[List]
+  } returns List(1)
+
+  val `toList errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).to[List]
+  } returns Nil
+
+  val `toStream answer` = test {
+    Result.answer(1).to[Stream]
+  } returns Stream(1)
+
+  val `toStream errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).to[Stream]
+  } returns Stream.empty[Int]
+
+  val `toOption answer` = test {
+    Result.answer(1).toOption
+  } returns Some(1)
+
+  val `toOption errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toOption
+  } returns None
+
+  val `toEither answer` = test {
+    Result.answer(1).toEither
+  } returns Right(1)
+
+  val `toEither errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toEither
+  } satisfies (v => v.isLeft)
+
+  val `getOrElse answer` = test {
+    Result.answer(1).getOrElse(0)
+  } returns 1
+
+  val `getOrElse errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).getOrElse(0)
+  } returns 0
+
+  val `| answer` = test {
+    Result.answer(1) | 0
+  } returns 1
+
+  val `| errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()) | 0
+  } returns 0
+
+  val `valueOr answer` = test {
+    Result.answer(1).valueOr(_ => 0)
+  } returns 1
+
+  val `valueOr errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).valueOr(_ => 0)
+  } returns 0
+
+  val `filter answer` = test {
+    Result.answer(1) filter (_ == 1)
+  } returns Answer(1)
+
+  val `filter answer` = test {
+    Result.answer(1) filter (_ == 0)
+  } returns Errata(Nil)
+
+  val `filter errata` = test {
+    Errata[String, Nothing](Nil) filter (_.isEmpty)
+  } returns Errata(Nil)
+
+  val `withFilter errata monadic` = test {
+    for {
+      x <- Answer(1)
+      if x == 0
+      y = x + 1
+    } yield y
+  } returns Errata(Nil)
+
+  val `withFilter answer monadic` = test {
+    for {
+      x <- Answer(1)
+      if x == 1
+      y = x + 1
+    } yield y
+  } returns Answer(2)
+
+}
+

--- a/core-test/src/tests.scala
+++ b/core-test/src/tests.scala
@@ -1,11 +1,7 @@
-package rapture.core.scalazResult.test
+package rapture.core.test
 
 import rapture.core._
-import rapture.core.scalazResult.ResultT
 import rapture.test._
-import scalaz._
-import Scalaz._
-
 
 object Tests extends TestSuite {
 
@@ -13,49 +9,244 @@ object Tests extends TestSuite {
   case class BetaException() extends Exception
   case class MiscException() extends Exception
 
+  def alpha(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, AlphaException] = mode.wrap {
+    if(x == 0) mode.exception(AlphaException())
+    else if(x == 1) throw MiscException()
+    else 0
+  }
+
+  def beta(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, BetaException] = mode.wrap {
+    if(x == 0) mode.exception(BetaException())
+    else if(x == 1) throw MiscException()
+    else 0
+  }
+
+  val `Successful Result` = test {
+    import modes.returnResult._
+    alpha(2)
+  } returns Answer(0)
+
+  val `Unforeseen Result` = test {
+    import modes.returnResult._
+    alpha(1)
+  } returns Unforeseen(MiscException())
+
+  val `Expected error Result` = test {
+    import modes.returnResult._
+    alpha(0)
+  } satisfies { case Errata(_) => true case _ => false }
+
+  val `FlatMapped Successful Result` = test {
+    import modes.returnResult._
+    for {
+      a <- alpha(2)
+      b <- beta(2)
+    } yield a + b
+  } returns Answer(0)
+
+  val `FlatMapped first fails` = test {
+    import modes.returnResult._
+    for {
+      a <- alpha(0)
+      b <- beta(2)
+    } yield a + b
+  } satisfies (_.exceptions == Vector(AlphaException()))
+
+  val `FlatMapped second fails` = test {
+    import modes.returnResult._
+    for {
+      a <- alpha(2)
+      b <- beta(0)
+    } yield a + b
+  } satisfies (_.exceptions == Vector(BetaException()))
+
+  val `Resolving errata 1` = test {
+    import modes.returnResult._
+    val result = for(a <- alpha(2); b <- beta(0)) yield a + b
+    result.resolve(
+      each[AlphaException] { e => 10 },
+      each[BetaException] { e => 20 }
+    )
+  } returns Answer(20)
+
+  val `Resolving errata 2` = test {
+    import modes.returnResult._
+    val result = for(a <- alpha(0); b <- beta(2)) yield a + b
+    result.resolve(
+      each[AlphaException] { e => 10 },
+      each[BetaException] { e => 20 }
+    )
+  } returns Answer(10)
+
+  val `Catching success` = test {
+    Result.catching[AlphaException] {
+      "success"
+    }
+  } returns Answer("success")
+
+  val `Catching failure` = test {
+    Result.catching[AlphaException] {
+      throw AlphaException()
+    }
+  } satisfies (_.exceptions == Vector(AlphaException()))
+
+  val `Catching unforeseen` = test {
+    Result.catching[AlphaException] {
+      throw BetaException()
+    }
+  } returns Unforeseen(BetaException())
+
   val `Checking isErrata with errata` = test {
-    ResultT.errata(Option(AlphaException())).run.get.isErrata
+    Result.errata(AlphaException()).isErrata
   } returns true
 
   val `Checking isErrata with answer` = test {
-    ResultT.answer(Option(1)).run.get.isErrata
+    Result.answer(1).isErrata
   } returns false
 
   val `Checking isAnswer with errata` = test {
-    ResultT.errata(Option(AlphaException())).run.get.isAnswer
+    Result.errata(AlphaException()).isAnswer
   } returns false
 
   val `Checking isAnswer with answer` = test {
-    ResultT.answer(Option(1)).run.get.isAnswer
+    Result.answer(1).isAnswer
   } returns true
 
   val `Checking isUnforeseen with answer` = test {
-    ResultT.answer(Option(1)).run.get.isUnforeseen
+    Result.answer(1).isUnforeseen
   } returns false
 
   val `Checking isUnforeseen with errata` = test {
-    ResultT.errata(Option(AlphaException())).run.get.isUnforeseen
+    Result.errata(AlphaException()).isUnforeseen
   } returns false
 
+  val `Checking isUnforeseen with unforeseen` = test {
+    Result.catching[AlphaException] {
+      throw BetaException()
+    }.isUnforeseen
+  } returns true
+
+  val `Fold answer` = test {
+    Result.answer(1).fold(
+      a => a + 1,
+      e => 0
+    )
+  } returns 2
+
+  val `Fold errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).fold(
+      a => a + 1,
+      e => 0
+    )
+  } returns 0
+
+  val `Exists answer` = test {
+    Result.answer(1).exists(_ == 1)
+  } returns true
+
+  val `Exists answer none found` = test {
+    Result.answer(1).exists(_ == 0)
+  } returns false
+
+  val `Exists errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).exists(_ == 1)
+  } returns false
+
+  val `Forall answer` = test {
+    Result.answer(1).forall(_ == 1)
+  } returns true
+
+  val `Forall answer none found` = test {
+    Result.answer(1).forall(_ == 0)
+  } returns false
+
+  val `Forall errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).forall(_ == 1)
+  } returns true
+
+  val `toList answer` = test {
+    Result.answer(1).to[List]
+  } returns List(1)
+
+  val `toList errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).to[List]
+  } returns Nil
+
+  val `toStream answer` = test {
+    Result.answer(1).to[Stream]
+  } returns Stream(1)
+
+  val `toStream errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).to[Stream]
+  } returns Stream.empty[Int]
+
+  val `toOption answer` = test {
+    Result.answer(1).toOption
+  } returns Some(1)
+
+  val `toOption errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toOption
+  } returns None
+
+  val `toEither answer` = test {
+    Result.answer(1).toEither
+  } returns Right(1)
+
+  val `toEither errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).toEither
+  } satisfies (v => v.isLeft)
+
+  val `getOrElse answer` = test {
+    Result.answer(1).getOrElse(0)
+  } returns 1
+
+  val `getOrElse errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).getOrElse(0)
+  } returns 0
+
+  val `| answer` = test {
+    Result.answer(1) | 0
+  } returns 1
+
+  val `| errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()) | 0
+  } returns 0
+
+  val `valueOr answer` = test {
+    Result.answer(1).valueOr(_ => 0)
+  } returns 1
+
+  val `valueOr errata` = test {
+    Result.errata[Int, AlphaException](AlphaException()).valueOr(_ => 0)
+  } returns 0
+
   val `filter answer` = test {
-    ResultT.answer(Option(1)) filter (_ == 1)
-  } returns ResultT(Some(Answer(1)))
+    Result.answer(1) filter (_ == 1)
+  } returns Answer(1)
+
+  val `filter answer` = test {
+    Result.answer(1) filter (_ == 0)
+  } returns Errata(Nil)
+
+  val `filter errata` = test {
+    Errata[String, Nothing](Nil) filter (_.isEmpty)
+  } returns Errata(Nil)
 
   val `withFilter errata monadic` = test {
     for {
-      x <- Option(Answer(1)) |> ResultT.apply
+      x <- Answer(1)
       if x == 0
       y = x + 1
     } yield y
-  } returns ResultT(Some(Errata(Nil)))
+  } returns Errata(Nil)
 
   val `withFilter answer monadic` = test {
     for {
-      x <- Option(Answer(1)) |> ResultT.apply
+      x <- Answer(1)
       if x == 1
       y = x + 1
     } yield y
-  } returns ResultT(Some(Answer(2)))
+  } returns Answer(2)
 
 }
 

--- a/core-test/src/tests.scala
+++ b/core-test/src/tests.scala
@@ -1,7 +1,11 @@
-package rapture.core.test
+package rapture.core.scalazResult.test
 
 import rapture.core._
+import rapture.core.scalazResult.ResultT
 import rapture.test._
+import scalaz._
+import Scalaz._
+
 
 object Tests extends TestSuite {
 
@@ -9,244 +13,49 @@ object Tests extends TestSuite {
   case class BetaException() extends Exception
   case class MiscException() extends Exception
 
-  def alpha(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, AlphaException] = mode.wrap {
-    if(x == 0) mode.exception(AlphaException())
-    else if(x == 1) throw MiscException()
-    else 0
-  }
-  
-  def beta(x: Int)(implicit mode: Mode[_]): mode.Wrap[Int, BetaException] = mode.wrap {
-    if(x == 0) mode.exception(BetaException())
-    else if(x == 1) throw MiscException()
-    else 0
-  }
-
-  val `Successful Result` = test {
-    import modes.returnResult._
-    alpha(2)
-  } returns Answer(0)
-
-  val `Unforeseen Result` = test {
-    import modes.returnResult._
-    alpha(1)
-  } returns Unforeseen(MiscException())
-
-  val `Expected error Result` = test {
-    import modes.returnResult._
-    alpha(0)
-  } satisfies { case Errata(_) => true case _ => false }
-
-  val `FlatMapped Successful Result` = test {
-    import modes.returnResult._
-    for {
-      a <- alpha(2)
-      b <- beta(2)
-    } yield a + b
-  } returns Answer(0)
-
-  val `FlatMapped first fails` = test {
-    import modes.returnResult._
-    for {
-      a <- alpha(0)
-      b <- beta(2)
-    } yield a + b
-  } satisfies (_.exceptions == Vector(AlphaException()))
-
-  val `FlatMapped second fails` = test {
-    import modes.returnResult._
-    for {
-      a <- alpha(2)
-      b <- beta(0)
-    } yield a + b
-  } satisfies (_.exceptions == Vector(BetaException()))
-
-  val `Resolving errata 1` = test {
-    import modes.returnResult._
-    val result = for(a <- alpha(2); b <- beta(0)) yield a + b
-    result.resolve(
-      each[AlphaException] { e => 10 },
-      each[BetaException] { e => 20 }
-    )
-  } returns Answer(20)
-
-  val `Resolving errata 2` = test {
-    import modes.returnResult._
-    val result = for(a <- alpha(0); b <- beta(2)) yield a + b
-    result.resolve(
-      each[AlphaException] { e => 10 },
-      each[BetaException] { e => 20 }
-    )
-  } returns Answer(10)
-
-  val `Catching success` = test {
-    Result.catching[AlphaException] {
-      "success"
-    }
-  } returns Answer("success")
-
-  val `Catching failure` = test {
-    Result.catching[AlphaException] {
-      throw AlphaException()
-    }
-  } satisfies (_.exceptions == Vector(AlphaException()))
-  
-  val `Catching unforeseen` = test {
-    Result.catching[AlphaException] {
-      throw BetaException()
-    }
-  } returns Unforeseen(BetaException())
-
   val `Checking isErrata with errata` = test {
-    Result.errata(AlphaException()).isErrata
+    ResultT.errata(Option(AlphaException())).run.get.isErrata
   } returns true
 
   val `Checking isErrata with answer` = test {
-    Result.answer(1).isErrata
+    ResultT.answer(Option(1)).run.get.isErrata
   } returns false
 
   val `Checking isAnswer with errata` = test {
-    Result.errata(AlphaException()).isAnswer
+    ResultT.errata(Option(AlphaException())).run.get.isAnswer
   } returns false
 
   val `Checking isAnswer with answer` = test {
-    Result.answer(1).isAnswer
+    ResultT.answer(Option(1)).run.get.isAnswer
   } returns true
 
   val `Checking isUnforeseen with answer` = test {
-    Result.answer(1).isUnforeseen
+    ResultT.answer(Option(1)).run.get.isUnforeseen
   } returns false
 
   val `Checking isUnforeseen with errata` = test {
-    Result.errata(AlphaException()).isUnforeseen
+    ResultT.errata(Option(AlphaException())).run.get.isUnforeseen
   } returns false
-
-  val `Checking isUnforeseen with unforeseen` = test {
-    Result.catching[AlphaException] {
-      throw BetaException()
-    }.isUnforeseen
-  } returns true
-
-  val `Fold answer` = test {
-    Result.answer(1).fold(
-      a => a + 1,
-      e => 0
-    )
-  } returns 2
-
-  val `Fold errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).fold(
-      a => a + 1,
-      e => 0
-    )
-  } returns 0
-
-  val `Exists answer` = test {
-    Result.answer(1).exists(_ == 1)
-  } returns true
-
-  val `Exists answer none found` = test {
-    Result.answer(1).exists(_ == 0)
-  } returns false
-
-  val `Exists errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).exists(_ == 1)
-  } returns false
-
-  val `Forall answer` = test {
-    Result.answer(1).forall(_ == 1)
-  } returns true
-
-  val `Forall answer none found` = test {
-    Result.answer(1).forall(_ == 0)
-  } returns false
-
-  val `Forall errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).forall(_ == 1)
-  } returns true
-
-  val `toList answer` = test {
-    Result.answer(1).to[List]
-  } returns List(1)
-
-  val `toList errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).to[List]
-  } returns Nil
-
-  val `toStream answer` = test {
-    Result.answer(1).to[Stream]
-  } returns Stream(1)
-
-  val `toStream errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).to[Stream]
-  } returns Stream.empty[Int]
-
-  val `toOption answer` = test {
-    Result.answer(1).toOption
-  } returns Some(1)
-
-  val `toOption errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).toOption
-  } returns None
-
-  val `toEither answer` = test {
-    Result.answer(1).toEither
-  } returns Right(1)
-
-  val `toEither errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).toEither
-  } satisfies (v => v.isLeft)
-
-  val `getOrElse answer` = test {
-    Result.answer(1).getOrElse(0)
-  } returns 1
-
-  val `getOrElse errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).getOrElse(0)
-  } returns 0
-
-  val `| answer` = test {
-    Result.answer(1) | 0
-  } returns 1
-
-  val `| errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()) | 0
-  } returns 0
-
-  val `valueOr answer` = test {
-    Result.answer(1).valueOr(_ => 0)
-  } returns 1
-
-  val `valueOr errata` = test {
-    Result.errata[Int, AlphaException](AlphaException()).valueOr(_ => 0)
-  } returns 0
 
   val `filter answer` = test {
-    Result.answer(1) filter (_ == 1)
-  } returns Answer(1)
-
-  val `filter answer` = test {
-    Result.answer(1) filter (_ == 0)
-  } returns Errata(Nil)
-
-  val `filter errata` = test {
-    Errata[String, Nothing](Nil) filter (_.isEmpty)
-  } returns Errata(Nil)
+    ResultT.answer(Option(1)) filter (_ == 1)
+  } returns ResultT(Some(Answer(1)))
 
   val `withFilter errata monadic` = test {
     for {
-      x <- Answer(1)
+      x <- Option(Answer(1)) |> ResultT.apply
       if x == 0
       y = x + 1
     } yield y
-  } returns Errata(Nil)
+  } returns ResultT(Some(Errata(Nil)))
 
   val `withFilter answer monadic` = test {
     for {
-      x <- Answer(1)
+      x <- Option(Answer(1)) |> ResultT.apply
       if x == 1
       y = x + 1
     } yield y
-  } returns Answer(2)
+  } returns ResultT(Some(Answer(2)))
 
 }
 


### PR DESCRIPTION
This PR brings a Scalaz Monad Transformer for the `Result` type.
`ResultT`simplifies deeply nested structures when computing over Results.

Ex.

``` scala
val r = for {
x <- Task(Result.catching[NumberFormatException](1)) |> ResultT.apply
y <- Task(Result.catching[NumberFormatException](2)) |> ResultT.apply
} yield x + y

val x = r.run.attemptRun

scala> val x = r.run.attemptRun
x: scalaz.\/[Throwable,rapture.core.Result[Int,NumberFormatException]] = \/-(Answer(3))
```

Same for any wrapping Monad such as `Option` `\/` `Future`, etc...
