### PR TITLE
Support for substituting `String`s (only `String`s) as keys in objects in JSON literals

### DIFF
--- a/data/shared/src/main/scala/context.scala
+++ b/data/shared/src/main/scala/context.scala
@@ -70,14 +70,14 @@ abstract class DataContextMacros[+Data <: DataType[Data, DataAst], -AstType <: D
         
         val stringsUsed: List[Boolean] = (listExprs.tree match {
           case Apply(_, bs) => bs.map {
-            case Apply(Apply(TypeApply(Select(_, TermName(nme)), _), _), _) => nme == "forceStringConversion"
+            case Apply(Apply(TypeApply(Select(_, nme), _), _), _) => nme.toString == "forceStringConversion"
           }
         })
 
         parseSource(text, stringsUsed) foreach { case (n, offset, msg) =>
           val oldPos = ys(n).asInstanceOf[Literal].pos
           
-          val newPos = oldPos.withPoint(oldPos.start + offset)
+          val newPos = oldPos.withPoint(oldPos.startOrPoint + offset)
           c.error(newPos, msg)
         }
         

--- a/data/shared/src/main/scala/data.scala
+++ b/data/shared/src/main/scala/data.scala
@@ -214,13 +214,17 @@ trait MutableDataType[+T <: DataType[T, AstType], AstType <: MutableDataAst]
 trait `Data#as` extends MethodConstraint
 trait `Data#normalize` extends MethodConstraint
 
-object ForcedConversion extends LowPriorityForcedConversion {
+object ForcedConversion extends ForcedConversion_1 {
   implicit def forceOptConversion[T, D](opt: Option[T])(implicit ser: Serializer[T, D]) =
     opt.map(t => ForcedConversion[D](ser.serialize(t), false)) getOrElse
         ForcedConversion[D](null, true)
+ 
+  // The name of this method is significant for some additional checking done in the macro `contextMacro`.
+  implicit def forceStringConversion[D](value: String)(implicit ser: Serializer[String, D]) =
+    ForcedConversion[D](ser.serialize(value), false)
 }
 
-trait LowPriorityForcedConversion {
+trait ForcedConversion_1 {
   implicit def forceConversion[T, D](t: T)(implicit ser: Serializer[T, D]) =
     ForcedConversion[D](ser.serialize(t), false)
 }


### PR DESCRIPTION
We can now write:

```
val key = "foo"
json"""{ $key: "bar" }"""
```
