### PR TITLE
Fix handling of null values in spray backend

### DIFF
--- a/json-spray/shared/src/main/scala/ast.scala
+++ b/json-spray/shared/src/main/scala/ast.scala
@@ -133,6 +133,7 @@ private[spray] object SprayAst extends JsonBufferAst {
 
   def isNumber(num: Any): Boolean = try {
     num match {
+      case JsNull => false
       case num: JsValue =>
         num.convertTo[Double]
         true


### PR DESCRIPTION
Spray will happily cast JSON nulls to Double.NaN, so null is falsely
assumed to be a number, which causes a whole lot of issues down the
line.
