### PR TITLE
Fix match error on http content type

### DIFF
--- a/http-jetty/shared/src/main/scala/servlet.scala
+++ b/http-jetty/shared/src/main/scala/servlet.scala
@@ -65,7 +65,7 @@ class JettyHttpRequest(req: HttpServletRequest, resp: HttpServletResponse) exten
         }
       }
       params.toMap
-    
+
     case MimeTypes.`application/x-www-form-urlencoded` =>
       val params = new HashMap[String, String]
       val enum = req.getParameterNames
@@ -75,6 +75,9 @@ class JettyHttpRequest(req: HttpServletRequest, resp: HttpServletResponse) exten
           params(name) = value
       }
       params.toMap
+
+    case _ =>
+      Map.empty[String, String]
   }
 
   private val input = {


### PR DESCRIPTION
One important case is sending json (supplying `application/json` content-type).
