### PR TITLE
Update i18n doc for to match updated toString implementation

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -218,7 +218,7 @@ For example,
 
 ```scala
 scala> fr"Bonjour" & en"Hello"
-res: I18n[String, Fr with En] = fr|en:"Hello"
+res: I18n[String, Fr with En] = fr&en:"Hello"
 ```
 
 Additionally `hashCode` and `equals` are implemented such that `I18nString`s


### PR DESCRIPTION
A trivial one character change to have i18n doc match up with https://github.com/propensive/rapture/pull/133
