### PR TITLE
Add support for http over unix sockets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,8 @@ lazy val rapture = project.in(file("."))
 lazy val raptureJVM = project.in(file(".raptureJVM"))
   .settings(moduleName := "rapture")
   .settings(raptureSettings)
-  .aggregate(baseJVM, coreJVM, timeJVM, uriJVM, codecJVM, cryptoJVM, csvJVM, ioJVM, fsJVM, netJVM, httpJVM, mimeJVM, cliJVM, logJVM, i18nJVM, googleTranslateJVM, textJVM, latexJVM, testJVM, dataJVM, xmlJVM, jsonJVM, htmlJVM, domJVM, coreScalazJVM, httpJsonJVM)
-  .dependsOn(baseJVM, coreJVM, timeJVM, uriJVM, codecJVM, cryptoJVM, csvJVM, ioJVM, fsJVM, netJVM, httpJVM, mimeJVM, cliJVM, logJVM, i18nJVM, googleTranslateJVM, textJVM, latexJVM, testJVM, dataJVM, xmlJVM, jsonJVM, htmlJVM, domJVM, coreScalazJVM, httpJsonJVM)
+  .aggregate(baseJVM, coreJVM, timeJVM, uriJVM, codecJVM, cryptoJVM, csvJVM, ioJVM, fsJVM, netJVM, httpJVM, mimeJVM, cliJVM, logJVM, i18nJVM, googleTranslateJVM, textJVM, latexJVM, testJVM, dataJVM, xmlJVM, jsonJVM, htmlJVM, domJVM, coreScalazJVM, httpJsonJVM, unixsocketJVM)
+  .dependsOn(baseJVM, coreJVM, timeJVM, uriJVM, codecJVM, cryptoJVM, csvJVM, ioJVM, fsJVM, netJVM, httpJVM, mimeJVM, cliJVM, logJVM, i18nJVM, googleTranslateJVM, textJVM, latexJVM, testJVM, dataJVM, xmlJVM, jsonJVM, htmlJVM, domJVM, coreScalazJVM, httpJsonJVM, unixsocketJVM)
   
 lazy val raptureJS = project.in(file(".raptureJS"))
   .settings(moduleName := "rapture")
@@ -145,6 +145,18 @@ lazy val net = crossProject.dependsOn(io)
  
 lazy val netJVM = net.jvm
 lazy val netJS = net.js
+
+// rapture-unixsocket
+// this is not a scala-js project - it may only be used on the jvm and on linux
+lazy val unixsocketJVM = (project in file("unixsocket/jvm")).dependsOn(io.jvm, core.jvm, net.jvm, uri.jvm)
+  .settings(moduleName := "rapture-unixsocket")
+  .settings(raptureSettings: _*)
+  .settings(libraryDependencies ++= Seq(
+    "com.kohlschutter.junixsocket"  %   "junixsocket-native"        % "2.0.4",
+    "com.kohlschutter.junixsocket"  %   "junixsocket-native-common" % "2.0.4",
+    "com.kohlschutter.junixsocket"  %   "junixsocket-common"        % "2.0.4",
+    "org.apache.httpcomponents"     %   "httpclient"                % "4.5.2"
+  ))
 
 // rapture-time
 lazy val time = crossProject.dependsOn(core)

--- a/unixsocket/jvm/src/main/scala/rapture/unixsocket/UnixSocketHttpClient.scala
+++ b/unixsocket/jvm/src/main/scala/rapture/unixsocket/UnixSocketHttpClient.scala
@@ -1,0 +1,98 @@
+package rapture.unixsocket
+
+import java.io.File
+import java.net.{Socket, InetSocketAddress}
+import java.util.concurrent.TimeUnit
+
+import org.apache.http.{HttpRequest, HttpHost}
+import org.apache.http.config.SocketConfig
+import org.apache.http.conn.{ManagedHttpClientConnection, HttpClientConnectionOperator, SchemePortResolver}
+import org.apache.http.impl.conn.{PoolingHttpClientConnectionManager, ManagedHttpClientConnectionFactory, DefaultHttpResponseParserFactory, DefaultRoutePlanner}
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.impl.io.DefaultHttpRequestWriterFactory
+import org.apache.http.protocol.HttpContext
+
+import org.newsclub.net.unix.{AFUNIXSocketAddress, AFUNIXSocket}
+
+object UnixSocketHttpClient {
+
+  /**
+    * Executes an HttpRequest
+    * @param host The custom HttpHost (the hostname is actually the socket file)
+    * @param request The HttpRequest (eg. GET /)
+    * @return The CloseableHttpResponse
+    */
+  def execute(host: HttpHost, request: HttpRequest) =
+    client.execute(host, request)
+
+  /**
+    * Create the customized http client
+    */
+  private val client = HttpClients
+    .custom
+    .setConnectionManager(connectionManager)
+    .setConnectionManagerShared(true)
+    .setRoutePlanner(routePlanner)
+    .build
+
+  /**
+    * The customized connection manager
+    */
+  private def connectionManager = new PoolingHttpClientConnectionManager(connectionOperator, connectionFactory, -1, TimeUnit.MILLISECONDS)
+
+  /**
+    * A route planner with our custom scheme port resolver
+    */
+  private def routePlanner = new DefaultRoutePlanner(schemePortResolver)
+
+  /**
+    * Our connection operator
+    * It will create unix socket connections for us
+    */
+  private def connectionOperator = new HttpClientConnectionOperator {
+
+    /**
+      * Creates the socket for our request, which is a unix socket.
+      */
+    def connect(conn: ManagedHttpClientConnection, host: HttpHost, localAddress: InetSocketAddress,
+                connectTimeout: Int, socketConfig: SocketConfig, context: HttpContext): Unit = {
+      val sock: Socket = AFUNIXSocket.newInstance
+      sock.setTcpNoDelay(socketConfig.isTcpNoDelay)
+      if (socketConfig.getRcvBufSize > 0) {
+        sock.setReceiveBufferSize(socketConfig.getRcvBufSize)
+      }
+      if (socketConfig.getSndBufSize > 0) {
+        sock.setSendBufferSize(socketConfig.getSndBufSize)
+      }
+      val linger: Int = socketConfig.getSoLinger
+      if (linger >= 0) {
+        sock.setSoLinger(true, linger)
+      }
+      sock.connect(new AFUNIXSocketAddress(new File(host.getHostName)), connectTimeout)
+      conn.bind(sock)
+    }
+
+    /**
+      * Can upgrade an http connection. This is only used for proxies - so we don't need it
+      */
+    def upgrade(conn: ManagedHttpClientConnection, host: HttpHost, context: HttpContext) =
+      throw new NotImplementedError("upgrade is not supported - a unix-socket cannot be accessed through a proxy")
+
+  }
+
+  /**
+    * A default managed connection factory
+    */
+  private def connectionFactory = new ManagedHttpClientConnectionFactory(
+    new DefaultHttpRequestWriterFactory(),
+    new DefaultHttpResponseParserFactory()
+  )
+
+  /**
+    * Resolves the port for the "unix" scheme
+    * We don't actually need a port, but an NPE will be thrown if we don't replace it.
+    */
+  private def schemePortResolver = new SchemePortResolver { def resolve(host: HttpHost) = 0 }
+
+}
+

--- a/unixsocket/jvm/src/main/scala/rapture/unixsocket/UnixSocketHttpUrl.scala
+++ b/unixsocket/jvm/src/main/scala/rapture/unixsocket/UnixSocketHttpUrl.scala
@@ -1,0 +1,20 @@
+package rapture.unixsocket
+
+import rapture.core.ParseException
+
+case class UnixSocketHttpUrl(socketFileName: String, queryString: String, queryParams: Option[String])
+
+object UnixSocketHttpUrl {
+
+  private val UnixSocketRegex = """unix:\/\/(\/[^:]+):(\/?[^\?]*)(\?[^\?]*)?""".r
+
+  @throws[ParseException]
+  def parse(unixSocketUrl: String): UnixSocketHttpUrl = {
+    unixSocketUrl match {
+      case UnixSocketRegex(unixSocket, queryUrl, queryParams) => UnixSocketHttpUrl(unixSocket, queryUrl, Option(queryParams))
+      case _ => throw new ParseException(unixSocketUrl, "unix socket url")
+    }
+  }
+
+}
+

--- a/unixsocket/jvm/src/main/scala/rapture/unixsocket/package.scala
+++ b/unixsocket/jvm/src/main/scala/rapture/unixsocket/package.scala
@@ -1,0 +1,111 @@
+package rapture
+
+import rapture.core.`package`._
+import rapture.core.Mode
+import rapture.io.OutputStreamBuilder
+import rapture.io.`package`._
+import rapture.net._
+import rapture.uri.UriContext
+
+import java.io._
+
+import org.apache.http.HttpHost
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods._
+import org.apache.http.entity.AbstractHttpEntity
+
+package object unixsocket {
+
+
+  implicit class EnrichedUnixUriContext(uc: UriContext.type) {
+    // `unix+http` as method name did not play well with the implicit conversion it seems :(
+    def unix(constants: List[String])(variables: List[String]) = {
+      var unixSocketUrl = "unix:" + constants.zip(variables :+ "").map { case (a, b) => a+b }.mkString
+      UnixSocketHttpUrl.parse(unixSocketUrl)
+    }
+  }
+
+
+  implicit def basicHttpSupport: HttpSupport[UnixSocketHttpUrl] = new HttpSupport[UnixSocketHttpUrl] {
+
+    def doHttp[C: PostType, T](unixSocketHttpUrl: UnixSocketHttpUrl, content: C,
+                               headers: Map[String, String] = Map(),method: String = "POST")
+                              (implicit mode: Mode[`NetUrl#httpPost`], httpTimeout: HttpTimeout,
+                               httpRedirectConfig: HttpRedirectConfig, httpCertificateConfig: HttpCertificateConfig,
+                               httpBasicAuthentication: HttpBasicAuthentication):
+                              mode.Wrap[HttpResponse, HttpExceptions with httpTimeout.Throws] =
+      mode wrap {
+
+        val host = HttpHost.create(s"unix://${unixSocketHttpUrl.socketFileName}")
+
+        val url = unixSocketHttpUrl.queryString + unixSocketHttpUrl.queryParams.getOrElse("")
+
+        class InvertedHttpEntity extends AbstractHttpEntity {
+
+          override def isRepeatable: Boolean = false
+
+          override def getContentLength: Long = -1
+
+          override def isStreaming: Boolean = false
+
+          override def getContent: InputStream = throw new UnsupportedOperationException
+
+          override def writeTo(outputStream: OutputStream): Unit = {
+            ensuring(OutputStreamBuilder.output(outputStream)) { out =>
+              ?[PostType[C]].sender(content) > out
+            }
+          }
+
+        }
+
+        val request = method.toUpperCase match {
+          case "GET"    => new HttpGet(url)
+          case "POST"   => {
+            val post = new HttpPost(url)
+            if(content != None)
+              post.setEntity(new InvertedHttpEntity)
+            post
+          }
+          case "PUT"    => {
+            val put = new HttpPut(url)
+            if(content != None)
+              put.setEntity(new InvertedHttpEntity)
+            put
+          }
+          case "DELETE" => new HttpDelete(url)
+        }
+
+        val config = RequestConfig
+          .custom()
+          .setConnectTimeout(httpTimeout.duration)
+          .build
+
+        request.setConfig(config)
+
+        def base64encode(content: String) =
+          NetUrl.base64.encode(content.getBytes("UTF-8")).mkString
+
+        httpBasicAuthentication.credentials foreach {
+          case (username, password) =>
+            request.setHeader("Authorization", "Basic " + base64encode(s"$username:$password"))
+        }
+
+        ?[PostType[C]]
+          .contentType
+          .foreach { ct => request.setHeader("Content-Type", ct.name) }
+
+        for((k, v) <- headers) request.setHeader(k, v)
+
+        val response = UnixSocketHttpClient.execute(host, request)
+
+        val statusLine = response.getStatusLine
+
+        val statusCode = statusLine.getStatusCode
+
+        val responseHeaders = response.getAllHeaders.map(header => (header.getName, List(header.getValue))).toMap
+
+        new HttpResponse(responseHeaders, statusCode, response.getEntity.getContent)
+      }
+  }
+
+}


### PR DESCRIPTION
Hi!

I managed to get HTTP to work over unix-sockets.
Example code looks like this:

```
import rapture.uri._
import rapture.io._
import rapture.net._
import rapture.unixsocket._
import rapture.json._, jsonBackends.jawn._

case class DockerVersionResponse(Version: String, ApiVersion: String, GitCommit: String, GoVersion: String, Os: String, Arch: String, KernelVersion: String, BuildTime: String)

val url: UnixSocketHttpUrl = uri"unix:///var/run/docker.sock:/version"
val httpGet = url.httpGet()
val response = httpGet.slurp[Char]
val version = Json.parse(response).as[DockerVersionResponse]
```

This change introduces new dependencies, allow me to explain why:
- junixsocket-native, junixsocket-native-common and junixsocket-common (2.0.4) for communication with the unix socket
- httpclient (4.5.2) for http requests - I was not able to create a custom socket for java's HTTPUrlConnection, which is used in rapture's http libs. It would not allow me to change the way sockets are created - or at least I didn't find a way.

Of course it's not possible to use this in scalajs, windows. It might work on OSX, but I've only tested linux.

Cheers

Timo
