### PR TITLE
Fix missing '>' html escape in dom formatter

### DIFF
--- a/dom/shared/src/main/scala/rapture/dom/format.scala
+++ b/dom/shared/src/main/scala/rapture/dom/format.scala
@@ -107,8 +107,8 @@ object DomFormatter {
 }
 
 trait DomFormatter[Output] {
-  protected def text(string: String): String = string.replaceAll("&", "&amp;").replaceAll("<", "&lt;")
-  protected def comment(string: String) = "<!--" + string.replaceAll("&", "&amp;").replaceAll("<", "&lt;") + "-->"
+  protected def text(string: String): String = string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+  protected def comment(string: String) = "<!--" + string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;") + "-->"
 
   def format(element: DomNode[_, _, _]): Output
 }


### PR DESCRIPTION
A pretty simple fix. Just added the missing `>` to `&gt;` escape to the dom formatter.
I also changed the `replaceAll` calls to `replace` calls. The latter also substitutes all occurences but doesn't treat the input as a regex, which will reduce escaping overhead slightly.

As far as I can see, no test will fail because of this. I had 14 test already failing on my machine before I introduced the fix though, so maybe they masked some new failure.
