### PR TITLE
[WIP] Move JSON/XML modules to separate projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -322,7 +322,7 @@ lazy val currencyJVM = currency.jvm
 lazy val currencyJS = currency.js
 
 // rapture-json
-lazy val json = crossProject.dependsOn(data)
+lazy val json = crossProject.dependsOn(core)
   .settings(moduleName := "rapture-json")
   .settings(raptureSettings:_*)
  

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val dataJVM = data.jvm
 lazy val dataJS = data.js
 
 // rapture-xml
-lazy val xml = crossProject.dependsOn(data)
+lazy val xml = crossProject.dependsOn(core)
   .settings(moduleName := "rapture-xml")
   .settings(raptureSettings:_*)
 

--- a/http-json/shared/src/main/scala/rapture/http-json/handler.scala
+++ b/http-json/shared/src/main/scala/rapture/http-json/handler.scala
@@ -18,11 +18,11 @@
 package rapture.http
 
 import rapture.json._
-import rapture.data._
 import rapture.mime._
 import rapture.io._
 import rapture.net._
-import rapture.codec._, encodings.`UTF-8`._
+import rapture.codec._
+import encodings.`UTF-8`._
 
 package object jsonInterop {
   implicit def jsonHttpHandler(implicit formatter: Formatter[JsonAst] { type Out = String }): HttpHandler[Json] =

--- a/json-argonaut/shared/src/main/scala/rapture/json-argonaut/ast.scala
+++ b/json-argonaut/shared/src/main/scala/rapture/json-argonaut/ast.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.argonaut
 
 import rapture.core._
-import rapture.data.DataTypes
 import rapture.json._
 
 import argonaut.{Json => AJson, _}

--- a/json-argonaut/shared/src/main/scala/rapture/json-argonaut/extractors.scala
+++ b/json-argonaut/shared/src/main/scala/rapture/json-argonaut/extractors.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.argonaut
 
 import rapture.json._
-import rapture.data._
 
 import argonaut.{Json => AJson, _}
 

--- a/json-argonaut/shared/src/main/scala/rapture/json-argonaut/parse.scala
+++ b/json-argonaut/shared/src/main/scala/rapture/json-argonaut/parse.scala
@@ -16,8 +16,6 @@
  */
 
 package rapture.json.jsonBackends.argonaut
-import rapture.core._
-import rapture.data._
 import rapture.json._
 
 import argonaut._

--- a/json-circe/shared/src/main/scala/rapture/json-circe/ast.scala
+++ b/json-circe/shared/src/main/scala/rapture/json-circe/ast.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.circe
 
 import rapture.core._
-import rapture.data.DataTypes
 import rapture.json._
 
 import io.circe.{Json => CirceJson}

--- a/json-circe/shared/src/main/scala/rapture/json-circe/extractors.scala
+++ b/json-circe/shared/src/main/scala/rapture/json-circe/extractors.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.circe
 
 import rapture.json._
-import rapture.data._
 
 import io.circe.{Json => CirceJson, _}
 

--- a/json-circe/shared/src/main/scala/rapture/json-circe/parse.scala
+++ b/json-circe/shared/src/main/scala/rapture/json-circe/parse.scala
@@ -16,8 +16,6 @@
  */
 
 package rapture.json.jsonBackends.circe
-import rapture.core._
-import rapture.data._
 import rapture.json._
 
 import io.circe.jawn._

--- a/json-jackson/shared/src/main/scala/rapture/json-jackson/ast.scala
+++ b/json-jackson/shared/src/main/scala/rapture/json-jackson/ast.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.jackson
 import rapture.core._
 import rapture.json._
-import rapture.data.DataTypes
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.node.NullNode
 

--- a/json-jackson/shared/src/main/scala/rapture/json-jackson/extractors.scala
+++ b/json-jackson/shared/src/main/scala/rapture/json-jackson/extractors.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.jackson
 
 import rapture.json._
-import rapture.data._
 import com.fasterxml.jackson.databind._
 
 private[jackson] trait Extractors {

--- a/json-jackson/shared/src/main/scala/rapture/json-jackson/package.scala
+++ b/json-jackson/shared/src/main/scala/rapture/json-jackson/package.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.jackson
 
 import rapture.json._
-import rapture.data._
 
 object `package` extends Extractors with Serializers {
   implicit val implicitJsonAst: JsonAst = JacksonAst

--- a/json-jackson/shared/src/main/scala/rapture/json-jackson/parse.scala
+++ b/json-jackson/shared/src/main/scala/rapture/json-jackson/parse.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.jackson
 import rapture.core._
 import rapture.json._
-import rapture.data._
 
 import com.fasterxml.jackson.databind._
 

--- a/json-jawn/shared/src/main/scala/rapture/json-jawn/ast.scala
+++ b/json-jawn/shared/src/main/scala/rapture/json-jawn/ast.scala
@@ -19,9 +19,6 @@ package rapture.json.jsonBackends.jawn
 
 import rapture.core._
 import rapture.json._
-import rapture.data.DataTypes
-import rapture.data.TypeMismatchException
-import rapture.data.MissingValueException
 
 import jawn.ast._
 

--- a/json-jawn/shared/src/main/scala/rapture/json-jawn/extractors.scala
+++ b/json-jawn/shared/src/main/scala/rapture/json-jawn/extractors.scala
@@ -17,7 +17,6 @@
 
 package rapture.json.jsonBackends.jawn
 
-import rapture.data._
 import rapture.json._
 
 import _root_.jawn.ast._

--- a/json-jawn/shared/src/main/scala/rapture/json-jawn/package.scala
+++ b/json-jawn/shared/src/main/scala/rapture/json-jawn/package.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.jawn
 
 import rapture.core._
-import rapture.data._
 import rapture.json._
 
 import _root_.jawn.{Parser => _, _}

--- a/json-jawn/shared/src/main/scala/rapture/json-jawn/parse.scala
+++ b/json-jawn/shared/src/main/scala/rapture/json-jawn/parse.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.jawn
 
 import rapture.core._
-import rapture.data._
 import rapture.json._
 
 import jawn.{Parser => JawnParser, _}

--- a/json-json4s/shared/src/main/scala/rapture/json-json4s/ast.scala
+++ b/json-json4s/shared/src/main/scala/rapture/json-json4s/ast.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.json4s
 
 import org.json4s._
-import rapture.data.DataTypes
 import rapture.json._
 
 private[json4s] object Json4sAst extends JsonBufferAst {

--- a/json-json4s/shared/src/main/scala/rapture/json-json4s/extractors.scala
+++ b/json-json4s/shared/src/main/scala/rapture/json-json4s/extractors.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.json4s
 
 import rapture.json._
-import rapture.data._
 
 import org.json4s._
 

--- a/json-json4s/shared/src/main/scala/rapture/json-json4s/parse.scala
+++ b/json-json4s/shared/src/main/scala/rapture/json-json4s/parse.scala
@@ -17,7 +17,6 @@
 
 package rapture.json.jsonBackends.json4s
 
-import rapture.data._
 import rapture.json._
 
 import org.json4s._

--- a/json-lift/shared/src/main/scala/rapture/json-lift/ast.scala
+++ b/json-lift/shared/src/main/scala/rapture/json-lift/ast.scala
@@ -19,7 +19,6 @@ package rapture.json.jsonBackends.lift
 
 import rapture.core._
 import rapture.json._
-import rapture.data.DataTypes
 
 import net.liftweb.json._
 

--- a/json-lift/shared/src/main/scala/rapture/json-lift/extractors.scala
+++ b/json-lift/shared/src/main/scala/rapture/json-lift/extractors.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.lift
 
 import rapture.json._
-import rapture.data._
 
 import net.liftweb.json._
 import JsonAST._

--- a/json-lift/shared/src/main/scala/rapture/json-lift/parse.scala
+++ b/json-lift/shared/src/main/scala/rapture/json-lift/parse.scala
@@ -19,7 +19,6 @@ package rapture.json.jsonBackends.lift
 
 import rapture.core._
 import rapture.json._
-import rapture.data._
 
 import net.liftweb.json._
 

--- a/json-play/shared/src/main/scala/rapture/json-play/ast.scala
+++ b/json-play/shared/src/main/scala/rapture/json-play/ast.scala
@@ -19,7 +19,6 @@ package rapture.json.jsonBackends.play
 
 import rapture.core._
 import rapture.json._
-import rapture.data.DataTypes
 
 import play.api.libs.json.{Json => PJson, _}
 

--- a/json-play/shared/src/main/scala/rapture/json-play/extraction.scala
+++ b/json-play/shared/src/main/scala/rapture/json-play/extraction.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.play
 
 import rapture.json._
-import rapture.data._
 
 import play.api.libs.json._
 

--- a/json-play/shared/src/main/scala/rapture/json-play/parse.scala
+++ b/json-play/shared/src/main/scala/rapture/json-play/parse.scala
@@ -19,7 +19,6 @@ package rapture.json.jsonBackends.play
 
 import rapture.core._
 import rapture.json._
-import rapture.data._
 
 import play.api.libs.json.{Json => PJson}
 

--- a/json-spray/shared/src/main/scala/rapture/json-spray/ast.scala
+++ b/json-spray/shared/src/main/scala/rapture/json-spray/ast.scala
@@ -19,7 +19,6 @@ package rapture.json.jsonBackends.spray
 
 import rapture.core._
 import rapture.json._
-import rapture.data.DataTypes
 
 import spray.json._
 

--- a/json-spray/shared/src/main/scala/rapture/json-spray/extraction.scala
+++ b/json-spray/shared/src/main/scala/rapture/json-spray/extraction.scala
@@ -18,7 +18,6 @@
 package rapture.json.jsonBackends.spray
 
 import rapture.json._
-import rapture.data._
 
 import spray.json._
 

--- a/json-spray/shared/src/main/scala/rapture/json-spray/parse.scala
+++ b/json-spray/shared/src/main/scala/rapture/json-spray/parse.scala
@@ -20,8 +20,6 @@ package rapture.json.jsonBackends.spray
 import rapture.core._
 import rapture.json._
 
-import rapture.data._
-
 import spray.json._
 
 private[spray] object SprayParser extends Parser[String, JsonBufferAst] {

--- a/json-test/shared/src/test/scala/rapture/json-test/java8TimeTests.scala
+++ b/json-test/shared/src/test/scala/rapture/json-test/java8TimeTests.scala
@@ -20,7 +20,6 @@ package rapture.json.test
 import java.time._
 
 import rapture.core.ParseException
-import rapture.data.Parser
 import rapture.json.jsonBackends._
 import rapture.json.{JsonAst, _}
 import rapture.test.{Programme, TestSuite}

--- a/json-test/shared/src/test/scala/rapture/json-test/tests.scala
+++ b/json-test/shared/src/test/scala/rapture/json-test/tests.scala
@@ -17,12 +17,9 @@
 
 package rapture.json.test
 
-import rapture.core._
 import rapture.json._
-import rapture.data.{DataTypes, Parser}
 import rapture.test._
 
-import scala.util
 
 class TestRun extends Programme {
   include(PlayTests)

--- a/json/shared/src/main/scala/rapture/json/ast.scala
+++ b/json/shared/src/main/scala/rapture/json/ast.scala
@@ -17,13 +17,56 @@
 
 package rapture.json
 
-import rapture.core._
-import rapture.data._
 
 /** Represents a JSON ast implementation which is used throughout this library */
-trait JsonAst extends DataAst {
+trait JsonAst {
+
+  /** Dereferences the named element within the JSON object. */
+  def dereferenceObject(obj: Any, element: String): Any =
+    getObject(obj)(element)
+
+  /** Returns at `Iterator[String]` over the names of the elements in the JSON object. */
+  def getKeys(obj: Any): Iterator[String] =
+    getObject(obj).keys.iterator
+
+  /** Gets the indexed element from the parsed JSON array. */
+  def dereferenceArray(array: Any, element: Int): Any =
+    getArray(array)(element)
+
+  /** Tests if the element represents an `Object` */
+  def isObject(any: Any): Boolean
+
+  /** Tests if the element represents an `Array` */
+  def isArray(any: Any): Boolean
+
+  /** Tests if the element represents a `Boolean` */
+  def isBoolean(any: Any): Boolean
+
+  /** Tests if the element represents a `String` */
+  def isString(any: Any): Boolean
+
+  /** Tests if the element represents a number */
+  def isNumber(any: Any): Boolean
+
+  /** Tests if the element represents a `null` */
+  def isNull(any: Any): Boolean
 
   def isScalar(any: Any) = isBoolean(any) || isNumber(any) || isString(any)
+
+  /** Extracts a JSON object as a `Map[String, Any]` from the parsed JSON. */
+  def getObject(obj: Any): Map[String, Any]
+
+  def getChildren(obj: Any): Seq[Any] = {
+    val m = getObject(obj)
+    getKeys(obj).to[List] map m
+  }
+
+  def fromObject(obj: Map[String, Any]): Any
+
+  /** Extracts a JSON array as a `Seq[Any]` from the parsed JSON. */
+  def getArray(array: Any): Seq[Any]
+
+  def fromArray(array: Seq[Any]): Any
 
   /** Extracts a `Boolean` from the parsed JSON. */
   def getBoolean(boolean: Any): Boolean
@@ -45,18 +88,6 @@ trait JsonAst extends DataAst {
 
   def fromBigDecimal(number: BigDecimal): Any
 
-  /** Tests if the element represents a `Boolean` */
-  def isBoolean(any: Any): Boolean
-
-  /** Tests if the element represents a `String` */
-  def isString(any: Any): Boolean
-
-  /** Tests if the element represents a number */
-  def isNumber(any: Any): Boolean
-
-  /** Tests if the element represents a `null` */
-  def isNull(any: Any): Boolean
-
   /** The value used to represent a `null` */
   def nullValue: Any
 
@@ -70,7 +101,7 @@ trait JsonAst extends DataAst {
     else if (isNull(any)) DataTypes.Null
     else throw MissingValueException()
 
-  def convert(v: Any, ast: DataAst): Any = {
+  def convert(v: Any, ast: JsonAst): Any = {
     val oldAst = ast.asInstanceOf[JsonAst]
     if (oldAst.isString(v)) fromString(oldAst.getString(v))
     else if (oldAst.isBoolean(v)) fromBoolean(oldAst.getBoolean(v))
@@ -83,4 +114,22 @@ trait JsonAst extends DataAst {
   protected def typeTest(pf: PartialFunction[Any, Unit])(v: Any) = pf.isDefinedAt(v)
 }
 
-trait JsonBufferAst extends JsonAst with MutableDataAst
+object DataTypes {
+  sealed class DataType(val name: String)
+  case object Number extends DataType("number")
+  case object String extends DataType("string")
+  case object Null extends DataType("null")
+  case object Boolean extends DataType("boolean")
+  case object Array extends DataType("array")
+  case object Object extends DataType("object")
+  case object Scalar extends DataType("scalar")
+  case object Container extends DataType("container")
+  case object Any extends DataType("any")
+}
+
+trait JsonBufferAst extends JsonAst {
+  def setObjectValue(obj: Any, name: String, value: Any): Any
+  def setArrayValue(array: Any, index: Int, value: Any): Any
+  def removeObjectValue(obj: Any, name: String): Any
+  def addArrayValue(array: Any, value: Any): Any
+}

--- a/json/shared/src/main/scala/rapture/json/context.scala
+++ b/json/shared/src/main/scala/rapture/json/context.scala
@@ -18,10 +18,62 @@
 package rapture.json
 
 import rapture.base._
-import rapture.core._
-import rapture.data._
 
 import language.experimental.macros
+abstract class DataContextMacros[+Data <: DataType[Data, JsonAst], -AstType <: JsonAst] {
+
+  def parseSource(s: List[String], stringsUsed: List[Boolean]): Option[(Int, Int, String)]
+
+  def dataCompanion(c: BlackboxContext): c.Expr[DataCompanion[Data, AstType]]
+
+  def contextMacro(c: BlackboxContext)(exprs: c.Expr[ForcedConversion[Data]]*)(
+    parser: c.Expr[Parser[String, AstType]]): c.Expr[Data] = {
+    import c.universe._
+
+    c.prefix.tree match {
+      case Select(Apply(Apply(_, List(Apply(_, rawParts))), _), _) =>
+        val ys = rawParts.to[List]
+        val text = rawParts map { case lit @ Literal(Constant(part: String)) => part }
+
+        val listExprs = c.Expr[List[ForcedConversion[Data]]](q"_root_.scala.List(..${exprs.map(_.tree).to[List]})")
+
+        val stringsUsed: List[Boolean] = listExprs.tree match {
+          case Apply(_, bs) =>
+            bs.map {
+              case Apply(Apply(TypeApply(Select(_, nme), _), _), _) => nme.toString == "forceStringConversion"
+            }
+        }
+
+        parseSource(text, stringsUsed) foreach {
+          case (n, offset, msg) =>
+            val oldPos = ys(n).asInstanceOf[Literal].pos
+
+            val newPos = oldPos.withPoint(oldPos.start + offset)
+            c.error(newPos, msg)
+        }
+
+        val listParts = c.Expr[List[ForcedConversion[Data]]](q"_root_.scala.List(..$rawParts)")
+
+        val comp = dataCompanion(c)
+
+        reify {
+          val sb = new StringBuilder
+          val textParts = listParts.splice.iterator
+          val expressions: Iterator[ForcedConversion[_]] = listExprs.splice.iterator
+
+          sb.append(textParts.next())
+
+          while (textParts.hasNext) {
+            sb.append(
+              comp.splice.construct(MutableCell(expressions.next.value), Vector())(parser.splice.ast).toBareString)
+            sb.append(textParts.next)
+          }
+
+          comp.splice.construct(MutableCell(parser.splice.parse(sb.toString).get), Vector())(parser.splice.ast)
+        }
+    }
+  }
+}
 
 private[json] object JsonDataMacros extends DataContextMacros[Json, JsonAst] {
 
@@ -66,6 +118,128 @@ private[json] object JsonBufferDataMacros extends DataContextMacros[JsonBuffer, 
       parser: c.Expr[Parser[String, JsonBufferAst]]): c.Expr[JsonBuffer] =
     super.contextMacro(c)(exprs: _*)(parser)
 }
+
+object patternMatching {
+  object exactArrays {
+    implicit val implicitArrayMachingConfig = new ArrayMatchingConfig { def checkLengths = true }
+  }
+
+  object exactObjects {
+    implicit val implicitArrayMachingConfig = new ObjectMatchingConfig { def checkSizes = true }
+  }
+
+  object exact {
+    implicit val implicitArrayMachingConfig = new ObjectMatchingConfig with ArrayMatchingConfig {
+      def checkSizes = true
+      def checkLengths = true
+    }
+  }
+}
+
+object ArrayMatchingConfig {
+  implicit val ignoreByDefault = new ArrayMatchingConfig { def checkLengths = false }
+}
+
+object ObjectMatchingConfig {
+  implicit val ignoreByDefault = new ObjectMatchingConfig { def checkSizes = false }
+}
+
+trait ArrayMatchingConfig { def checkLengths: Boolean }
+trait ObjectMatchingConfig { def checkSizes: Boolean }
+
+class DataContext[+Data <: DataType[Data, JsonAst], -AstType <: JsonAst](companion: DataCompanion[Data, AstType],
+                                                                         sc: StringContext) {
+
+  protected def uniqueNonSubstring(s: String) = {
+    var cur, m = 0
+    s foreach { c =>
+      cur = if (c == '_') cur + 1 else 0
+      m = m max cur
+    }
+    "_" * (m + 1)
+  }
+
+  def unapplySeq[D <: DataType[D, JsonAst]](data: D)(
+    implicit arrayMatching: ArrayMatchingConfig,
+    objectMatching: ObjectMatchingConfig,
+    parser: Parser[String, AstType]): Option[Seq[DataType[D, JsonAst]]] =
+    try {
+      val placeholder = uniqueNonSubstring(sc.parts.mkString)
+      val PlaceholderNumber = (placeholder + "([0-9]+)" + placeholder).r
+      val count = Iterator.from(0)
+      val txt = sc.parts.reduceLeft(_ + s""""${placeholder}${count.next()}${placeholder}" """ + _)
+
+      val paths: Array[Vector[Either[Int, String]]] =
+        Array.fill[Vector[Either[Int, String]]](sc.parts.length - 1)(Vector())
+
+      val arrayLengths = new collection.mutable.HashMap[Vector[Either[Int, String]], Int]
+      val objectSizes = new collection.mutable.HashMap[Vector[Either[Int, String]], Int]
+
+      def extract(any: Any, path: Vector[Either[Int, String]]): Unit = {
+        // FIXME: Avoid using isScalar if possible
+        if (parser.ast.isScalar(any)) {
+          val ext = data.$extract(path).as[Any]
+          if (data.$extract(path).as[Any] != any) throw new Exception("Value doesn't match (1)")
+        } else if (parser.ast.isObject(any)) {
+          val obj = parser.ast.getObject(any)
+          objectSizes(path) = obj.size
+          obj foreach {
+            case (k, v) =>
+              if (parser.ast.isString(v)) parser.ast.getString(v) match {
+                case str: CharSequence =>
+                  str match {
+                    case PlaceholderNumber(n) =>
+                      paths(n.toInt) = path :+ Right(k)
+                    case _ => extract(v, path :+ Right(k))
+                  }
+              } else extract(v, path :+ Right(k))
+          }
+        } else if (parser.ast.isArray(any)) {
+          val array = parser.ast.getArray(any)
+          if (arrayMatching.checkLengths) arrayLengths(path) = array.length
+          array.zipWithIndex foreach {
+            case (e, i) =>
+              if (parser.ast.isString(e)) parser.ast.getString(e) match {
+                case str: CharSequence =>
+                  str match {
+                    case PlaceholderNumber(n) =>
+                      paths(n.toInt) = path :+ Left(i)
+                    case _ => extract(e, path :+ Left(i))
+                  }
+              } else extract(e, path :+ Left(i))
+          }
+        } else throw new Exception("Value doesn't match (2)")
+      }
+
+      extract(parser.parse(txt).get, Vector())
+
+      // Using a ListBuffer to work around SI-8947
+      val extractsBuffer = new collection.mutable.ListBuffer[D]
+      paths foreach { p =>
+        extractsBuffer += data.$extract(p)
+      }
+      val extracts = extractsBuffer.toList
+      extracts.foreach(_.$normalize)
+      val matchedArrayLengths = arrayLengths.forall {
+        case (p, len) =>
+          parser.ast.getArray(data.$extract(p).$normalize).length == len
+      }
+
+      val matchedObjectSizes = objectSizes.forall {
+        case (p, s) =>
+          if (objectMatching.checkSizes) parser.ast.getObject(data.$extract(p).$normalize).size == s
+          else parser.ast.getObject(data.$extract(p).$normalize).size >= 0
+      }
+
+      if (extracts.exists(_.$root.value == null) || !matchedArrayLengths || !matchedObjectSizes)
+        None
+      else Some(extracts)
+    } catch {
+      case e: Exception =>
+        None
+    }
+}
+
 
 /** Provides support for JSON literals, in the form json" { } " or json""" { } """.
   * Interpolation is used to substitute variable names into the JSON, and to extract values

--- a/json/shared/src/main/scala/rapture/json/data.scala
+++ b/json/shared/src/main/scala/rapture/json/data.scala
@@ -1,0 +1,368 @@
+/*
+  Rapture, version 2.0.0. Copyright 2010-2016 Jon Pretty, Propensive Ltd.
+
+  The primary distribution site is
+
+    http://rapture.io/
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+  compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License is
+  distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package rapture.json
+
+import rapture.core._
+
+import scala.util.Try
+
+import language.dynamics
+
+@implicitNotFound("Cannot find an implicit Formatter for ${AstType} data.")
+trait Formatter[-AstType <: JsonAst] {
+  type Out
+  def format(any: Any): Out
+}
+
+object DataCompanion { object Empty }
+
+object serializedNames {
+  object inUnderscoreStyle {
+    def apply[V, D] = nameMapperImplicit[V, D]
+    implicit def nameMapperImplicit[V, D] = new NameMapper[V, D] {
+      def encode(name: String): String = name.flatMap {
+        case lower if lower.isLower => lower.toString
+        case upper if upper.isUpper => s"_$upper".toLowerCase
+        case other => other.toString
+      }
+
+      def decode(name: String): String = name.foldLeft(("", false)) {
+        case ((acc, _), '_') => (acc, true)
+        case ((acc, true), other) => (acc+other.toString.toUpperCase, false)
+        case ((acc, false), other) => (acc+other, false)
+      }._1
+    }
+  }
+  
+  object inDashedStyle {
+    def apply[V, D] = nameMapperImplicit[V, D]
+    implicit def nameMapperImplicit[V, D] = new NameMapper[V, D] {
+      def encode(name: String): String = name.flatMap {
+        case lower if lower.isLower => lower.toString
+        case upper if upper.isUpper => s"-$upper".toLowerCase
+        case other => other.toString
+      }
+
+      def decode(name: String): String = name.foldLeft(("", false)) {
+        case ((acc, _), '-') => (acc, true)
+        case ((acc, true), other) => (acc+other.toString.toUpperCase, false)
+        case ((acc, false), other) => (acc+other, false)
+      }._1
+    }
+  }
+  
+  object identical {
+    def apply[V, D] = nameMapperImplicit[V, D]
+    implicit def nameMapperImplicit[V, D] = new NameMapper[V, D] {
+      def encode(name: String): String = name
+      def decode(name: String): String = name
+    }
+  }
+}
+
+object NameMapper {
+  implicit def identityNameMapper[V, D]: NameMapper[V, D] = serializedNames.identical[V, D]
+}
+
+trait NameMapper[+Value, +Data] {
+  def encode(name: String): String
+  def decode(name: String): String
+}
+
+trait DataCompanion[+Type <: DataType[Type, JsonAst], -AstType <: JsonAst] {
+
+  type ParseMethodConstraint <: MethodConstraint
+
+  def empty(implicit ast: AstType) =
+    construct(MutableCell(ast.fromObject(Map())), Vector())
+
+  def construct(any: MutableCell, path: Vector[Either[Int, String]])(implicit ast: AstType): Type
+
+  def parse[Source: StringSerializer](s: Source)(implicit mode: Mode[ParseMethodConstraint],
+                                                 parser: Parser[Source, AstType]): mode.Wrap[Type, ParseException] =
+    mode wrap {
+      construct(try MutableCell(parser.parse(s).get)
+                catch {
+                  case e: NoSuchElementException => mode.exception(ParseException(String(s)))
+                },
+                Vector())(parser.ast)
+    }
+
+  def raw(value: Any)(implicit ast: AstType): Type =
+    construct(MutableCell(value), Vector())
+
+  def format[T <: DataType[T, AstType]](data: T)(implicit f: Formatter[_ <: AstType]): f.Out =
+    f.format(data.$normalize)
+
+}
+
+case class DynamicApplication[D](path: List[Either[Int, String]], application: ForcedConversion2[D])
+
+case class DynamicPath[D](path: List[Either[Int, String]]) extends Dynamic {
+  def self = selectDynamic("self")
+  def selectDynamic(v: String) = DynamicPath[D](Right(v) :: path)
+  def applyDynamic(v: String)(i: Int) = DynamicPath[D](Left(i) :: Right(v) :: path)
+  def apply(i: Int) = DynamicPath[D](Left(i) :: path)
+
+  def updateDynamic(p: String)(value: ForcedConversion2[D]) =
+    DynamicApplication(Right(p) :: path, value)
+
+  def update(i: Int, value: ForcedConversion2[D]) =
+    DynamicApplication(Left(i) :: path, value)
+}
+
+case class MutableCell(var value: Any)
+
+trait DynamicData[+T <: DynamicData[T, AstType], +AstType <: JsonAst] extends Dynamic {
+
+  /** Assumes the Json object wraps a `Map`, and extracts the element `key`. */
+  def selectDynamic(key: String): T = $deref(Right(key) +: $path)
+  
+  def self = selectDynamic("self")
+
+  //def applyDynamic(key: String)(i: Int = 0): T = $deref(Left(i) +: Right(key) +: $path)
+
+  def $deref($path: Vector[Either[Int, String]]): T
+  def $path: Vector[Either[Int, String]]
+
+}
+
+object DataType {
+
+  class DataClassOperations[T <: DataType[T, AstType], AstType <: JsonAst](dataType: T) {
+    def ++[S <: DataType[S, Rep] forSome { type Rep }](b: S): T = {
+      val ast = dataType.$ast
+
+      def merge(a: Any, b: Any): Any = {
+        if (ast.isObject(a) && ast.isObject(b)) {
+          ast.fromObject(ast.getKeys(b).foldLeft(ast.getObject(a)) {
+            case (as, k) =>
+              as + (k -> {
+                    if (as contains k) merge(as(k), ast.dereferenceObject(b, k)) else ast.dereferenceObject(b, k)
+                  })
+          })
+        } else if (ast.isArray(a) && ast.isArray(b)) ast.fromArray(ast.getArray(a) ++ ast.getArray(b))
+        else b
+      }
+
+      val left = dataType.$normalize
+      val right = if (ast != b.$ast) ast.convert(b.$normalize, b.$ast.asInstanceOf[JsonAst]) else b.$normalize
+
+      dataType.$wrap(merge(left, right), Vector())
+    }
+
+    def copy(pvs: (DynamicPath[T] => DynamicApplication[_ <: DataType[T, _ <: AstType]])*): T = {
+      dataType.$wrap(pvs.foldLeft(dataType.$normalize) {
+        case (cur, pv) =>
+          val dPath = pv(DynamicPath(Nil))
+          val ast = dataType.$ast
+
+          if (dPath.application.nothing) cur
+          else {
+
+            def nav(path: List[Either[Int, String]], dest: Any, v: Any): Any = path match {
+              case Nil =>
+                v
+
+              case Right(next) :: list =>
+                val d = try ast.dereferenceObject(dest, next)
+                catch { case e: Exception => ast.fromObject(Map()) }
+                val src = ast.getObject(if (ast.isObject(dest)) dest else Map())
+                ast.fromObject(src + ((next, nav(list, d, v))))
+
+              case Left(next) :: list =>
+                val d = try ast.dereferenceArray(dest, next)
+                catch { case e: Exception => ast.fromArray(List()) }
+                val src = if (ast.isArray(dest)) ast.getArray(dest) else Nil
+                ast.fromArray(src.padTo(next + 1, ast.fromObject(Map())).updated(next, nav(list, d, v)))
+            }
+
+            nav(dPath.path.reverse, cur, dPath.application.value)
+          }
+      })
+    }
+  }
+}
+
+trait DataType[+T <: DataType[T, AstType], +AstType <: JsonAst] {
+  val $root: MutableCell
+  implicit def $ast: AstType
+  def $path: Vector[Either[Int, String]]
+  def $normalize: Any = doNormalize(false)
+  def $wrap(any: Any, $path: Vector[Either[Int, String]] = Vector()): T
+  def $deref($path: Vector[Either[Int, String]] = Vector()): T
+  def $extract($path: Vector[Either[Int, String]]): T
+
+  def \(key: String): T = $deref(Right(key) +: $path)
+
+  def \\(key: String): T = $wrap($ast.fromArray(derefRecursive(key, $normalize)))
+
+  def toBareString: String
+
+  private def derefRecursive(key: String, any: Any): List[Any] =
+    if (!$ast.isObject(any)) Nil
+    else
+      $ast.getKeys(any).to[List].flatMap {
+        case k if k == key => List($ast.dereferenceObject(any, k))
+        case k => derefRecursive(key, $ast.dereferenceObject(any, k))
+      }
+
+  protected def doNormalize(orEmpty: Boolean): Any = {
+    yCombinator[(Any, Vector[Either[Int, String]]), Any] { fn =>
+      {
+        case (j, Vector()) => j: Any
+        case (j, t :+ e) =>
+          fn(({
+            if (e.bimap(x => $ast.isArray(j), x => $ast.isObject(j))) {
+              try e.bimap($ast.dereferenceArray(j, _), $ast.dereferenceObject(j, _))
+              catch {
+                case TypeMismatchException(exp, fnd) => throw TypeMismatchException(exp, fnd)
+                case exc: Exception =>
+                  if (orEmpty) DataCompanion.Empty
+                  else {
+                    e match {
+                      case Left(e) => throw MissingValueException(s"[$e]")
+                      case Right(e) => throw MissingValueException(e)
+                    }
+                  }
+              }
+            } else
+              throw TypeMismatchException(
+                  if ($ast.isArray(j)) DataTypes.Array else DataTypes.Object,
+                  e.bimap(l => DataTypes.Array, r => DataTypes.Object)
+              )
+          }, t))
+      }
+    }($root.value -> $path)
+  }
+
+  /** Assumes the Json object is wrapping a `T`, and casts (intelligently) to that type. */
+  def as[S](implicit ext: Extractor[S, T], mode: Mode[`Data#as`]): mode.Wrap[S, ext.Throws] =
+    ext.extract(this.asInstanceOf[T], $ast, mode)
+
+  def is[S](implicit ext: Extractor[S, T]): Boolean =
+    try {
+      ext.extract(this.asInstanceOf[T], $ast, modes.throwExceptions())
+      true
+    } catch {
+      case e: Exception => false
+    }
+
+  def apply(i: Int = 0): T = $deref(Left(i) +: $path)
+
+  override def equals(any: Any) =
+    try {
+      any match {
+        case any: DataType[_, _] => $normalize == any.$normalize
+        case _ => false
+      }
+    } catch { case e: Exception => false }
+
+  override def hashCode = $root.value.hashCode ^ 3271912
+
+}
+
+trait MutableDataType[+T <: DataType[T, AstType], AstType <: JsonBufferAst] extends DataType[T, AstType] {
+
+  def $updateParents(p: Vector[Either[Int, String]], newVal: Any): Unit =
+    p match {
+      case Vector() =>
+        $root.value = newVal
+      case Left(idx) +: init =>
+        val jb = $deref(init)
+        val newJb = $ast.setArrayValue(Try(jb.$normalize).getOrElse($ast.fromArray(Nil)), idx, newVal)
+
+        if (jb match {
+              case jb: AnyRef =>
+                newJb match {
+                  case newJb: AnyRef => jb ne newJb
+                  case _ => false
+                }
+              case jb => jb == newJb
+            }) $updateParents(init, newJb)
+      case Right(key) +: init =>
+        val jb = $deref(init)
+        val newJb = $ast.setObjectValue(Try(jb.$normalize).getOrElse($ast.fromObject(Map())), key, newVal)
+
+        if (jb match {
+              case jb: AnyRef =>
+                newJb match {
+                  case newJb: AnyRef => jb ne newJb
+                  case _ => false
+                }
+              case jb => jb == newJb
+            }) $updateParents(init, newJb)
+    }
+
+  /** Updates the element `key` of the JSON object with the value `v` */
+  def updateDynamic(key: String)(v: ForcedConversion2[T]): Unit =
+    if (!v.nothing)
+      $updateParents($path, $ast.setObjectValue(Try($normalize).getOrElse($ast.fromObject(Map())), key, v.value))
+
+  /** Updates the `i`th element of the JSON array with the value `v` */
+  def update[T2](i: Int, v: T2)(implicit ser: Serializer[T2, T]): Unit =
+    $updateParents($path, $ast.setArrayValue(Try($normalize).getOrElse($ast.fromArray(Nil)), i, ser.serialize(v)))
+
+  /** Removes the specified key from the JSON object */
+  def -=(k: String): Unit = $updateParents($path, $ast.removeObjectValue(doNormalize(true), k))
+
+  /** Adds the specified value to the JSON array */
+  def +=[T2](v: T2)(implicit ser: Serializer[T2, T]): Unit = {
+    val r = doNormalize(true)
+    val insert = if (r == DataCompanion.Empty) $ast.fromArray(Nil) else r
+    $updateParents($path, $ast.addArrayValue(insert, ser.serialize(v)))
+  }
+}
+
+trait `Data#as` extends MethodConstraint
+trait `Data#normalize` extends MethodConstraint
+
+object ForcedConversion2 extends ForcedConversion2_1 {
+  implicit def forceOptConversion[T, D](opt: Option[T])(implicit ser: Serializer[T, D]) =
+    opt.map(t => ForcedConversion2[D](ser.serialize(t), false)) getOrElse
+      ForcedConversion2[D](null, true)
+}
+
+trait ForcedConversion2_1 {
+  implicit def forceConversion[T, D](t: T)(implicit ser: Serializer[T, D]) =
+    ForcedConversion2[D](ser.serialize(t), false)
+}
+
+case class ForcedConversion2[-D](value: Any, nothing: Boolean)
+
+object ForcedConversion extends ForcedConversion_1 {
+  implicit def forceOptConversion[T, D](opt: Option[T])(implicit ser: Serializer[T, D]) =
+    opt.map(t => ForcedConversion[D](ser.serialize(t), false)) getOrElse
+      ForcedConversion[D](null, true)
+}
+
+trait ForcedConversion_1 extends ForcedConversion_2 {
+  implicit def forceConversion[T, D](t: T)(implicit ser: Serializer[T, D]) =
+    ForcedConversion[D](ser.serialize(t), false)
+}
+
+trait ForcedConversion_2 {
+  // The name of this method is significant for some additional checking done in the macro `contextMacro`.
+  implicit def forceStringConversion[D, T: StringSerializer](value: T)(implicit ser: Serializer[String, D]) =
+    ForcedConversion[D](ser.serialize(?[StringSerializer[T]].serialize(value)), false)
+}
+
+case class ForcedConversion[-D](value: Any, nothing: Boolean)
+
+case class ParseException(source: String, line: Option[Int] = None, column: Option[Int] = None)
+    extends Exception("Failed to parse source")

--- a/json/shared/src/main/scala/rapture/json/exceptions.scala
+++ b/json/shared/src/main/scala/rapture/json/exceptions.scala
@@ -1,0 +1,14 @@
+package rapture.json
+
+
+sealed abstract class DataGetException(msg: String) extends RuntimeException(msg)
+
+case class TypeMismatchException(found: DataTypes.DataType, expected: DataTypes.DataType)
+  extends DataGetException(s"type mismatch: Expected ${expected.name} but found ${found.name}")
+
+case class MissingValueException(name: String = "")
+  extends DataGetException(
+    if (name.isEmpty)
+      "missing value"
+    else s"missing value: $name")
+

--- a/json/shared/src/main/scala/rapture/json/extractors.scala
+++ b/json/shared/src/main/scala/rapture/json/extractors.scala
@@ -18,11 +18,146 @@
 package rapture.json
 
 import rapture.core._
-import rapture.data._
 
 import scala.util._
-
 import language.higherKinds
+
+case class FilterException() extends Exception("value was removed by filter")
+case class NotEmptyException() extends Exception
+
+@implicitNotFound("cannot extract type ${T} from ${D}.")
+abstract class Extractor[T, -D] extends Functor[({ type L[x] = Extractor[x, D] })#L, T] { ext =>
+  type Throws <: Exception
+
+  def safeExtract(any: D,
+                  ast: JsonAst,
+                  prefix: Option[Either[Int, String]],
+                  mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, Throws] = mode.wrap[T, Throws] {
+    try mode.unwrap(extract(any, ast, mode))
+    catch {
+      case e @ TypeMismatchException(_, _) => mode.exception(e)
+      case e @ MissingValueException(_) => mode.exception(e)
+    }
+  }
+
+  def extract(any: D, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, Throws]
+
+  def rawMap[T2](fn: (T, Mode[_ <: MethodConstraint]) => T2): Extractor[T2, D] = new Extractor[T2, D] {
+    def extract(any: D, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T2, Throws] =
+      mode.wrap(fn(mode.unwrap(ext.extract(any, ast, mode)), mode.generic))
+  }
+
+  def filter(pred: T => Boolean): Extractor[T, D] { type Throws = ext.Throws with FilterException } =
+    new Extractor[T, D] {
+      type Throws = ext.Throws with FilterException
+      def extract(any: D, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, Throws] = mode.wrap {
+        val result = mode.unwrap(ext.extract(any, ast, mode))
+        if (pred(result)) result else mode.exception[T, FilterException](FilterException())
+      }
+    }
+
+  def orElse[TS >: T, T2 <: TS, D2 <: D](ext2: => Extractor[T2, D2]): Extractor[TS, D2] { type Throws = DataGetException } =
+    new Extractor[TS, D2] {
+      type Throws = DataGetException
+      def extract(any: D2, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[TS, Throws] = mode.wrap {
+        try mode.unwrap(ext.extract(any, ast, mode))
+        catch {
+          case e: Exception => mode.unwrap(ext2.extract(any, ast, mode))
+        }
+      }
+    }
+}
+
+object Extractor {
+  implicit def anyExtractor[Data <: DataType[_, JsonAst]]: Extractor[Any, Data] { type Throws = Nothing } =
+    new Extractor[Any, Data] {
+      type Throws = Nothing
+      def extract(value: Data, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Any, Throws] =
+        mode.wrap(value.$normalize)
+    }
+}
+
+object GeneralExtractors {
+
+  def tryExtractor[Data <: DataType[Data, _ <: JsonAst], T](
+                                                             implicit ext: Extractor[T, Data]): Extractor[Try[T], Data] { type Throws = Nothing } =
+    new Extractor[Try[T], Data] {
+      type Throws = Nothing
+      def extract(any: Data, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Try[T], Throws] = mode.wrap {
+        try ext.extract(any.$wrap(any.$normalize), any.$ast, modes.returnTry())
+        catch {
+          case e: Exception => Failure(e)
+        }
+      }
+    }
+
+  def optionExtractor[Data <: DataType[Data, _ <: JsonAst], T](
+                                                                implicit ext: Extractor[T, Data]): Extractor[Option[T], Data] { type Throws = Nothing } = {
+
+    new Extractor[Option[T], Data] {
+      type Throws = Nothing
+      def extract(any: Data, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Option[T], Throws] =
+        mode.wrap {
+          try ext.extract(any.$wrap(any.$normalize), any.$ast, modes.returnOption())
+          catch {
+            case e: Exception => None
+          }
+        }
+    }
+  }
+
+  def noneExtractor[Data <: DataType[_, JsonAst]]
+  : Extractor[None.type, Data] { type Throws = DataGetException with NotEmptyException } =
+    new Extractor[None.type, Data] {
+      type Throws = DataGetException with NotEmptyException
+      def extract(value: Data, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[None.type, Throws] =
+        mode.wrap {
+          val v = value.$wrap(value.$normalize)
+          if (ast.isObject(v) && ast.getKeys(v).isEmpty) None
+          else mode.exception[None.type, NotEmptyException](NotEmptyException())
+        }
+    }
+
+  def genSeqExtractor[T, Coll[_], Data <: DataType[Data, _ <: JsonAst]](
+                                                                         implicit cbf: scala.collection.generic.CanBuildFrom[Nothing, T, Coll[T]],
+                                                                         ext: Extractor[T, Data]): Extractor[Coll[T], Data] { type Throws = ext.Throws } = {
+
+    new Extractor[Coll[T], Data] {
+      type Throws = ext.Throws
+      def extract(value: Data, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Coll[T], Throws] =
+        mode.wrap {
+          mode.catching[DataGetException, Coll[T]] {
+            val v = value.$wrap(value.$normalize)
+            v.$ast
+              .getArray(v.$root.value)
+              .to[List]
+              .zipWithIndex
+              .map {
+                case (e, i) =>
+                  mode.unwrap(ext.safeExtract(v.$wrap(e), v.$ast, Some(Left(i)), mode), s"($i)")
+              }
+              .to[Coll]
+          }
+        }
+    }
+  }
+
+  def mapExtractor[K, T, Data <: DataType[Data, _ <: JsonAst]](
+                                                                implicit ext: Extractor[T, Data],
+                                                                ext2: StringParser[K]): Extractor[Map[K, T], Data] { type Throws = ext.Throws with ext2.Throws } =
+    new Extractor[Map[K, T], Data] {
+      type Throws = ext.Throws with ext2.Throws
+      def extract(value: Data, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Map[K, T], Throws] =
+        mode.wrap {
+          value.$ast.getObject(value.$normalize) map {
+            case (k, v) =>
+              mode.unwrap(ext2.parse(k, mode)) -> mode.unwrap(
+                ext.safeExtract(value.$wrap(v), value.$ast, Some(Right(k)), mode))
+          }
+        }
+    }
+}
+
 
 private[json] case class JsonCastExtractor[T](ast: JsonAst, dataType: DataTypes.DataType)
 
@@ -53,20 +188,20 @@ private[json] trait Extractors_1 extends Extractors_2 {
   implicit def jsonExtractor(implicit ast: JsonAst): Extractor[Json, Json] { type Throws = DataGetException } =
     new Extractor[Json, Json] {
       type Throws = DataGetException
-      def extract(any: Json, dataAst: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Json, DataGetException] =
+      def extract(any: Json, dataAst: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Json, DataGetException] =
         mode.wrap(mode.catching[DataGetException, Json](any.$wrap(any.$normalize)))
     }
 
   implicit val stringExtractor: Extractor[String, Json] { type Throws = DataGetException } =
     new Extractor[String, Json] {
       type Throws = DataGetException
-      def extract(any: Json, ast: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[String, DataGetException] =
+      def extract(any: Json, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[String, DataGetException] =
         mode.wrap(mode.catching[DataGetException, String](any.$ast.getString(any.$normalize)))
     }
 
   implicit val nullExtractor: Extractor[Null, Json] { type Throws = DataGetException } = new Extractor[Null, Json] {
     type Throws = DataGetException
-    override def extract(any: Json, ast: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Null, this.Throws] = {
+    override def extract(any: Json, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Null, this.Throws] = {
       mode.wrap(
           mode.catching[DataGetException, Null](
               if (any.$ast.isNull(any.$normalize)) null
@@ -78,7 +213,7 @@ private[json] trait Extractors_1 extends Extractors_2 {
   implicit val doubleExtractor: Extractor[Double, Json] { type Throws = DataGetException } =
     new Extractor[Double, Json] {
       type Throws = DataGetException
-      def extract(any: Json, ast: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Double, Throws] =
+      def extract(any: Json, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Double, Throws] =
         mode.wrap(mode.catching[DataGetException, Double](any.$ast.getDouble(any.$normalize)))
     }
 
@@ -87,7 +222,7 @@ private[json] trait Extractors_1 extends Extractors_2 {
   implicit val booleanExtractor: Extractor[Boolean, Json] { type Throws = DataGetException } =
     new Extractor[Boolean, Json] {
       type Throws = DataGetException
-      def extract(any: Json, ast: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Boolean, DataGetException] =
+      def extract(any: Json, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Boolean, DataGetException] =
         mode.wrap(any.$ast.getBoolean(any.$normalize))
     }
 
@@ -95,7 +230,7 @@ private[json] trait Extractors_1 extends Extractors_2 {
     new Extractor[BigDecimal, Json] {
       type Throws = DataGetException
       def extract(any: Json,
-                  ast: DataAst,
+                  ast: JsonAst,
                   mode: Mode[_ <: MethodConstraint]): mode.Wrap[BigDecimal, DataGetException] =
         mode.wrap(any.$ast.getBigDecimal(any.$normalize))
     }
@@ -120,14 +255,14 @@ private[json] trait Extractors_2 {
                                       ext: Extractor[T, Json]): Extractor[T, JsonBuffer] { type Throws = ext.Throws } =
     new Extractor[T, JsonBuffer] {
       type Throws = ext.Throws
-      def extract(any: JsonBuffer, ast: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, ext.Throws] =
+      def extract(any: JsonBuffer, ast: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, ext.Throws] =
         ext.extract(Json.construct(MutableCell(any.$root.value), Vector()), ast, mode)
     }
 
   implicit def jsonBufferToJsonExtractor(implicit ast: JsonBufferAst): Extractor[JsonBuffer, Json] =
     new Extractor[JsonBuffer, Json] {
       type Throws = DataGetException
-      def extract(any: Json, dataAst: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[JsonBuffer, Throws] =
+      def extract(any: Json, dataAst: JsonAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[JsonBuffer, Throws] =
         mode.wrap(JsonBuffer.construct(MutableCell(JsonDataType.jsonSerializer.serialize(any)), Vector()))
     }
 
@@ -136,7 +271,7 @@ private[json] trait Extractors_2 {
   } = new Extractor[S, Json] {
     type Throws = DataGetException with parser.Throws
     def extract(any: Json,
-                ast: DataAst,
+                ast: JsonAst,
                 mode: Mode[_ <: MethodConstraint]): mode.Wrap[S, DataGetException with parser.Throws] =
       mode.wrap(mode.unwrap(parser.parse(any.$ast.getString(any.$normalize), mode)))
   }

--- a/json/shared/src/main/scala/rapture/json/formatters.scala
+++ b/json/shared/src/main/scala/rapture/json/formatters.scala
@@ -18,7 +18,6 @@
 package rapture.json
 
 import rapture.core._
-import rapture.data._
 
 object formatters extends formatters_1 {
   object compact {

--- a/json/shared/src/main/scala/rapture/json/json.scala
+++ b/json/shared/src/main/scala/rapture/json/json.scala
@@ -18,7 +18,6 @@
 package rapture.json
 
 import rapture.core._
-import rapture.data._
 
 import language.experimental.macros
 
@@ -104,8 +103,8 @@ object Json extends JsonDataCompanion[Json, JsonAst] with Json_1 {
   implicit def stringParser(implicit parser: Parser[String, JsonAst],
                             mode: Mode[_ <: ParseMethodConstraint]): StringParser[Json] =
     new StringParser[Json] {
-      type Throws = rapture.data.ParseException
-      def parse(str: String, mode2: Mode[_ <: MethodConstraint]): mode2.Wrap[Json, rapture.data.ParseException] =
+      type Throws = rapture.json.ParseException
+      def parse(str: String, mode2: Mode[_ <: MethodConstraint]): mode2.Wrap[Json, rapture.json.ParseException] =
         mode2.wrap {
           mode.unwrap(Json.parse(str)(implicitly[StringSerializer[String]], mode, parser))
         }
@@ -123,7 +122,7 @@ object Json extends JsonDataCompanion[Json, JsonAst] with Json_1 {
     new Extractor[T, JsonDataType[_, _ <: JsonAst]] {
       type Throws = DataGetException
       def extract(value: JsonDataType[_, _ <: JsonAst],
-                  ast2: DataAst,
+                  ast2: JsonAst,
                   mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, DataGetException] =
         mode.wrap(ast2 match {
           case ast2: JsonAst =>

--- a/json/shared/src/main/scala/rapture/json/macros.scala
+++ b/json/shared/src/main/scala/rapture/json/macros.scala
@@ -18,7 +18,6 @@
 package rapture.json
 
 import rapture.base._
-import rapture.data._
 
 private[json] object JsonMacros {
   def jsonExtractorMacro[T: c.WeakTypeTag, Th](c: WhiteboxContext): c.Expr[Extractor[T, Json]] =
@@ -34,3 +33,246 @@ private[json] object JsonMacros {
       ast: c.Expr[JsonBufferAst]): c.Expr[Serializer[T, JsonBuffer]] =
     Macros.serializerMacro[T, JsonBuffer](c)(ast)
 }
+
+
+object Macros {
+
+  // FIXME: Include enclosing position in the HashSet too
+  val emittedWarnings = new collection.mutable.HashSet[String]
+
+  // FIXME: Consider adding this check for knownDirectSubclasses to support sealed case classes
+  // def impl[T: c.WeakTypeTag](c: WhiteboxContext): c.Tree = {
+  //   import c.universe._
+  //   def subs = weakTypeOf[T].typeSymbol.asClass.knownDirectSubclasses
+  //   val subs1 = subs
+  //   println(subs1)
+  //   val global = c.universe.asInstanceOf[tools.nsc.Global]
+  //   def checkSubsPostTyper = if (subs1 != subs)
+  //     c.error(c.macroApplication.pos, "sealed descendents appears after macro exansion")
+  //     val dummyTypTree =
+  //     new global.TypeTreeWithDeferredRefCheck()(() => { checkSubsPostTyper ; global.TypeTree(global.NoType) }).asInstanceOf[TypTree]
+  //   q"type T = $dummyTypTree; ${subs1.size} : _root_.scala.Int"
+  // }
+  // def numChildren[T]: Int = macro impl[T]
+
+  def extractorMacro[T: c.WeakTypeTag, Data: c.WeakTypeTag, Th](
+                                                                 c: WhiteboxContext): c.Expr[Extractor[T, Data]] = {
+    import c.universe._
+    import compatibility._
+
+    val extractorType = typeOf[Extractor[_, _]].typeSymbol.asType.toTypeConstructor
+    val nameMapperType = typeOf[NameMapper[_, _]].typeSymbol.asType.toTypeConstructor
+
+    val implicitSearchFailures = collection.mutable.ListMap[String, List[String]]().withDefault(_ => Nil)
+
+    val extractionType = weakTypeOf[T].typeSymbol.asClass
+
+    if (weakTypeOf[T] <:< typeOf[AnyVal]) {
+      val param = paramLists(c)(declarations(c)(weakTypeOf[T]).collect {
+        case t: MethodSymbol => t.asMethod
+      }.find(_.isPrimaryConstructor).get).head.head
+
+      val paramType = param.typeSignature
+
+      val inferredExtractor =
+        c.inferImplicitValue(appliedType(extractorType, List(paramType, weakTypeOf[Data])), false, false)
+
+      c.Expr[Extractor[T, Data]](q"$inferredExtractor.map { new ${weakTypeOf[T]}(_) }")
+
+    }/* else if (extractionType.isSealed) {
+
+      val subclasses = extractionType.knownDirectSubclasses.to[List]
+      def tsort(todo: Map[Set[String], Symbol], done: List[Symbol] = Nil): List[Symbol] = if(todo.isEmpty) done else {
+        val move = todo.filter { case (key, v) => (todo - key).forall(!_._1.subsetOf(key)) }
+        tsort(todo -- move.map(_._1), move.map(_._2).to[List] ::: done)
+      }
+
+      val paramSets = subclasses.map { subclass =>
+        (declarations(c)(subclass.asType.toType).collect {
+          case m: MethodSymbol if m.isCaseAccessor => m.asMethod
+        }.map(_.name.decodedName.toString).to[Set], subclass)
+      }
+
+      val sortedExtractors = tsort(paramSets.toMap).map { subclass =>
+        val searchType = appliedType(extractorType, List(subclass.asType.toType, weakTypeOf[Data]))
+        c.inferImplicitValue(searchType, false, false)
+      }
+
+      val NothingType = weakTypeOf[Nothing]
+
+      val throwsType = sortedExtractors.last.tpe.member(typeName(c, "Throws")).typeSignature
+
+      val combinedExtractors = sortedExtractors.reduceLeft { (left, right) => q"$left.orElse($right)" }
+
+      c.Expr[Extractor[T, Data]](q"""
+        (new _root_.rapture.data.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def extract(data: ${weakTypeOf[Data]}, ast: _root_.rapture.data.DataAst, mode: _root_.rapture.core.Mode[_  <: _root_.rapture.core.MethodConstraint]): mode.Wrap[${weakTypeOf[
+          T]}, Throws] = mode.wrap { $combinedExtractors }
+        }).asInstanceOf[_root_.rapture.data.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          type Throws = ${throwsType}
+        }]
+      """)
+
+    }*/ else {
+
+      require(weakTypeOf[T].typeSymbol.asClass.isCaseClass)
+
+      val typeDeclaration = companion(c)(weakTypeOf[T].typeSymbol).typeSignature
+      val valueParameters = paramLists(c)(declaration(c)(typeDeclaration, termName(c, "apply")).asMethod)
+      val defaults = valueParameters.flatten.map(_.asTerm.isParamWithDefault).zipWithIndex.filter(_._1).map(_._2 + 1).to[Set]
+
+      // FIXME integrate these into a fold
+      var throwsTypes: Set[Type] = Set(typeOf[DataGetException])
+
+      val params = declarations(c)(weakTypeOf[T]).collect {
+        case m: MethodSymbol if m.isCaseAccessor => m.asMethod
+      }.zipWithIndex map {
+        case (p, idx) =>
+          val nameMappingImplicit = c.inferImplicitValue(appliedType(nameMapperType, List(weakTypeOf[T], weakTypeOf[Data])), false, false)
+          val deref = q"""data.selectDynamic($nameMappingImplicit.encode(${p.name.decodedName.toString}))"""
+
+          val NothingType = weakTypeOf[Nothing]
+
+          val inferredImplicit =
+            try c.inferImplicitValue(appliedType(extractorType, List(p.returnType, weakTypeOf[Data])), false, false)
+            catch {
+              case e: Exception =>
+                implicitSearchFailures(p.returnType.toString) ::= p.name.decodedName.toString
+                null
+            }
+
+          val t = try {
+            inferredImplicit.tpe.member(typeName(c, "Throws")).typeSignature match {
+              case NothingType => List()
+              case refinedType: RefinedType => refinedType.parents
+              case typ: Type => List(typ)
+              case _ => ???
+            }
+          } catch {
+            case e: Exception => List()
+          }
+
+          if(!defaults.contains(idx + 1)) throwsTypes ++= t
+
+          // Borrowed from Shapeless
+          def companionRef(tpe: Type): Tree = {
+            val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+            val gTpe = tpe.asInstanceOf[global.Type]
+            val pre = gTpe.prefix
+            val sym = gTpe.typeSymbol
+            val cSym = sym.companionSymbol
+            if (cSym != NoSymbol) global.gen.mkAttributedRef(pre, cSym).asInstanceOf[Tree]
+            else Ident(tpe.typeSymbol.name.toTermName)
+          }
+
+
+          if (defaults.contains(idx + 1)) q"""
+          mode.unwrap(try $deref.as($inferredImplicit, mode.generic) catch { case e: Exception => mode.wrap(${companionRef(weakTypeOf[T])}.${termName(
+            c, "apply$default$" + (idx + 1))}.asInstanceOf[${p.returnType}]) }, ${"." + p.name.decodedName})
+          """ else q"""
+          mode.unwrap($deref.as($inferredImplicit, mode.generic), ${"." + p.name.decodedName})
+        """
+      }
+
+      if (implicitSearchFailures.nonEmpty) {
+        val paramStrings = implicitSearchFailures map {
+          case (t, p1 :: Nil) =>
+            s"parameter `$p1' of type $t"
+          case (t, p1 :: ps) =>
+            s"parameters ${ps.map(v => s"`$v'").mkString(", ")} and `$p1' of type $t"
+          case (t, Nil) =>
+            ??? // Doesn't happen
+        }
+        val errorString = paramStrings.to[List].reverse match {
+          case t1 :: Nil => t1
+          case t1 :: ts => s"${ts.mkString(", ")} and $t1"
+          case Nil => ??? // Doesn't happen
+        }
+        val plural =
+          if (implicitSearchFailures.flatMap(_._2).size > 1)
+            s"${weakTypeOf[Data].typeSymbol.name} extractors"
+          else
+            s"a ${weakTypeOf[Data].typeSymbol.name} extractor"
+
+        val err = s"Could not generate a ${weakTypeOf[Data].typeSymbol.name} extractor for case " +
+          s"class ${weakTypeOf[T].typeSymbol.name} because $plural for $errorString could not " +
+          s"be found"
+
+        if (!emittedWarnings.contains(err)) {
+          emittedWarnings += err
+          c.warning(NoPosition, err)
+        }
+      }
+
+      require(implicitSearchFailures.isEmpty)
+
+      val construction = c.Expr[T](q"""new ${weakTypeOf[T]}(..$params)""")
+
+      c.Expr[Extractor[T, Data]](q"""
+        (new _root_.rapture.json.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def extract(data: ${weakTypeOf[Data]}, ast: _root_.rapture.json.JsonAst, mode: _root_.rapture.core.Mode[_  <: _root_.rapture.core.MethodConstraint]): mode.Wrap[${weakTypeOf[
+        T]}, Throws] = mode.wrap { ${construction} }
+        }).asInstanceOf[_root_.rapture.json.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          type Throws = ${normalize(c)(typeIntersection(c)(throwsTypes.to[List]))}
+        }]
+      """)
+    }
+  }
+
+  def serializerMacro[T: c.WeakTypeTag, Data: c.WeakTypeTag](c: WhiteboxContext)(
+    ast: c.Expr[JsonAst]): c.Expr[Serializer[T, Data]] = {
+    import c.universe._
+    import compatibility._
+
+    val tpe = weakTypeOf[T].typeSymbol.asClass
+    val nameMapperType = typeOf[NameMapper[_, _]].typeSymbol.asType.toTypeConstructor
+    val serializer = typeOf[Serializer[_, _]].typeSymbol.asType.toTypeConstructor
+
+    if (weakTypeOf[T] <:< typeOf[AnyVal]) {
+
+      val param = paramLists(c)(declarations(c)(weakTypeOf[T]).collect {
+        case t: MethodSymbol => t.asMethod
+      }.find(_.isPrimaryConstructor).get).head.head
+
+      val paramName = param.name.decodedName.toString
+      val paramType = param.typeSignature
+      val inferredSerializer =
+        c.inferImplicitValue(appliedType(serializer, List(paramType, weakTypeOf[Data])), false, false)
+
+      val newName = termName(c, freshName(c)("param$"))
+
+      c.Expr[Serializer[T, Data]](q"$inferredSerializer.contramap[${weakTypeOf[T]}](_.${termName(c, paramName)})")
+    } else {
+      if (tpe.isCaseClass) {
+        val params = declarations(c)(weakTypeOf[T]).collect {
+          case m: MethodSymbol if m.isCaseAccessor => m.asMethod
+        }.map { p =>
+          val imp = c.inferImplicitValue(appliedType(serializer, List(p.returnType, weakTypeOf[Data])), false, false)
+          val appliedSerializerType = appliedType(nameMapperType, List(weakTypeOf[T], weakTypeOf[Data]))
+          val nameMapperImplicit = c.inferImplicitValue(appliedSerializerType, false, false)
+          q"""($nameMapperImplicit.encode(${p.name.decodedName.toString}),
+              $imp.serialize(${termName(c, "t")}.${p}))"""
+        }
+
+        c.Expr[Serializer[T, Data]](q"""new _root_.rapture.json.Serializer[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def serialize(t: ${weakTypeOf[T]}): _root_.scala.Any =
+            $ast.fromObject(_root_.scala.collection.immutable.Map(..$params).filterNot { v => $ast.isNull(v._2) })
+        }""")
+      } else if (tpe.isSealed) {
+        val cases = tpe.knownDirectSubclasses.to[List]
+        val caseClauses = cases.map { sc =>
+          val fullySpecifiedSerializer = appliedType(serializer, List(sc.asType.toType, weakTypeOf[Data]))
+          val caseSerializer = c.inferImplicitValue(fullySpecifiedSerializer, false, false)
+          val pattern = pq"v: ${sc.asClass}"
+          cq"${pattern} => $caseSerializer.serialize(v)"
+        }
+
+        c.Expr[Serializer[T, Data]](q"""new _root_.rapture.json.Serializer[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def serialize(t: ${weakTypeOf[T]}): _root_.scala.Any = t match { case ..$caseClauses }
+        }""")
+      } else throw new Exception()
+
+    }
+  }
+}
+

--- a/json/shared/src/main/scala/rapture/json/package.scala
+++ b/json/shared/src/main/scala/rapture/json/package.scala
@@ -16,22 +16,9 @@
  */
 
 package rapture.json
-
-import rapture.core._
-import rapture.data._
+import scala.language.implicitConversions
 
 object `package` {
-
-  val patternMatching = rapture.data.patternMatching
-
-  type Extractor[T, -D] = rapture.data.Extractor[T, D]
-  type Serializer[T, -D] = rapture.data.Serializer[T, D]
-  type DataGetException = rapture.data.DataGetException
-  type TypeMismatchException = rapture.data.TypeMismatchException
-  type MissingValueException = rapture.data.MissingValueException
-
-  val TypeMismatchException = rapture.data.TypeMismatchException
-  val MissingValueException = rapture.data.MissingValueException
 
   implicit def jsonStringContext(sc: StringContext)(implicit parser: Parser[String, JsonAst]) =
     new JsonStrings(sc)

--- a/json/shared/src/main/scala/rapture/json/parser.scala
+++ b/json/shared/src/main/scala/rapture/json/parser.scala
@@ -1,0 +1,10 @@
+package rapture.json
+
+import scala.annotation.implicitNotFound
+
+
+@implicitNotFound(msg = "Cannot find ${Ast} parser for values of type ${Source}")
+trait Parser[-Source, +Ast <: JsonAst] {
+  val ast: Ast
+  def parse(s: Source): Option[Any]
+}

--- a/json/shared/src/main/scala/rapture/json/serializers.scala
+++ b/json/shared/src/main/scala/rapture/json/serializers.scala
@@ -18,9 +18,20 @@
 package rapture.json
 
 import rapture.core._
-import rapture.data._
-
+import scala.annotation._
 import language.higherKinds
+
+@implicitNotFound(
+  "Cannot serialize type $"+"{T} to $"+"{D}. Please provide an implicit Serializer " +
+    "of type $"+"{T}.")
+trait Serializer[T, -D] { ser =>
+  def serialize(t: T): Any
+
+  def contramap[T2](fn: T2 => T) = new Serializer[T2, D] {
+    def serialize(t: T2): Any = ser.serialize(fn(t))
+  }
+
+}
 
 private[json] case class DirectJsonSerializer[T](ast: JsonAst)
 

--- a/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
+++ b/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
@@ -25,6 +25,7 @@ private[stdlib] object StdlibAst extends XmlBufferAst {
 
   override def dereferenceObject(obj: Any, element: String): Any = obj match {
     case n: Node if n.child.exists(_.label == element) => n \ element
+    case ns: NodeSeq if ns.exists(_.label == element) => ns.filter(_.label == element)
     case ns: NodeSeq if ns.exists(_.child.exists(_.label == element)) => ns \ element
     case _ => throw MissingValueException()
   }

--- a/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
+++ b/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
@@ -49,7 +49,7 @@ private[stdlib] object StdlibAst extends XmlBufferAst {
   def getObject(obj: Any): Map[String, Any] = obj match {
     case n: Node =>
       n.child.map { e =>
-        e.label -> e.child
+        n.label -> e
       }.toMap
     case n: NodeSeq =>
       n.flatMap(_.child.map { e =>
@@ -138,14 +138,18 @@ private[stdlib] object StdlibAst extends XmlBufferAst {
 
   def fromArray(array: Seq[Any]): Any = array.collect { case e: NodeSeq => e }.foldLeft(NodeSeq.Empty)(_ ++ _)
 
-  def fromObject(obj: Map[String, Any]): Any =
+  def fromObject(obj: Map[String, Any]): Any = {
     obj
       .to[List]
       .collect {
         case (k, v: NodeSeq) =>
-          Elem(null, k, Null, TopScope, true, v: _*): NodeSeq
+          v.map{ x =>
+            Elem(null, k, Null, TopScope, true, x): NodeSeq
+          }.foldLeft(NodeSeq.Empty)(_ ++ _)
       }
       .foldLeft(NodeSeq.Empty)(_ ++ _)
+  }
+
 
   def fromString(string: String): Any = Text(string)
 

--- a/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
+++ b/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
@@ -17,11 +17,7 @@
 
 package rapture.xml.xmlBackends.stdlib
 
-import rapture.core._
 import rapture.xml._
-import rapture.data.DataTypes
-import rapture.data.TypeMismatchException
-import rapture.data.MissingValueException
 
 import scala.xml._
 

--- a/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/parse.scala
+++ b/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/parse.scala
@@ -17,8 +17,6 @@
 
 package rapture.xml.xmlBackends.stdlib
 
-import rapture.core._
-import rapture.data._
 import rapture.xml._
 
 import scala.xml._

--- a/xml-test/shared/src/test/scala/rapture/xml-test/java8TimeTests.scala
+++ b/xml-test/shared/src/test/scala/rapture/xml-test/java8TimeTests.scala
@@ -21,7 +21,6 @@ import java.time._
 
 import rapture.core.ParseException
 import rapture.xml._
-import rapture.data.Parser
 import rapture.test._
 import rapture.xml.xmlBackends.stdlib
 import rapture.core.java8.time._

--- a/xml-test/shared/src/test/scala/rapture/xml-test/tests.scala
+++ b/xml-test/shared/src/test/scala/rapture/xml-test/tests.scala
@@ -24,6 +24,7 @@ import rapture.test._
 
 class TestRun extends Programme {
   include(StdlibTests)
+  include(StdlibPatternMatchTests)
 }
 
 private[test] case class Foo(alpha: String, beta: Int)
@@ -188,6 +189,27 @@ abstract class XmlTests(ast: XmlAst, parser: Parser[String, XmlAst]) extends Tes
     fooXML.alpha.as[String]
   } returns "Joe"
 
+  case class FooList(name: String, abc: List[String])
+
+  val `Serialize class with list` = test {
+    val user = FooList("Joe", List("abc", "1,2,3"))
+    Xml(user).toBareString
+  } returns """<name>Joe</name><abc>abc</abc><abc>1,2,3</abc>"""
+
+  val `Serialize class with list of elements and deserialize it` = test {
+    val user = FooList("Joe", List("abc", "1,2,3"))
+    Xml(user).as[FooList]
+  } returns FooList("Joe", List("abc", "1,2,3"))
+
+  val `Serialize class with list of elements and deserialize it (from XmlContext)` = test {
+    xml"""<a><name>Joe</name><abc>abc</abc><abc>1,2,3</abc></a>""".as[FooList]
+  } returns FooList("Joe", List("abc", "1,2,3"))
+
+  val `Extract list of elements` = test {
+    xml"""<a><name>Joe</name><abc>abc</abc><abc>1,2,3</abc></a>""".abc.as[List[String]]
+  } returns List("abc", "1,2,3")
+
+
   /*val `Serialize array` = test {
     Json(List(1, 2, 3)).toString
   } returns "123"
@@ -221,34 +243,34 @@ abstract class XmlPatternMatchingTests(ast: XmlAst, parser: Parser[String, XmlAs
 
   val source1 = Data.source1
   
-  val `Pattern matching` = test {
-    Xml("") match {
-      case xml"""""" => "Match"
-      case _ => "Does not match"
-    }
-  } returns "Match"
+//  val `Pattern matching` = test {
+//    Xml("<a>") match {
+//      case xml"""""""" => "Match"
+//      case _ => "Does not match"
+//    }
+//  } returns "Match"
 
   val `Match string` = test {
-    source1 match {
-      case xml"""<string>$h<string>""" => h.as[String]
+    source1.string match {
+      case xml"""<string>$h</string>""" => h.as[String]
     }
   } returns "Hello"
 
   val `Match int` = test {
-    source1 match {
-      case xml"""<int>$h<int>""" => h.as[Int]
+    source1.int match {
+      case xml"""<int>$h</int>""" => h.as[Int]
     }
   } returns 42
 
   val `Match double` = test {
-    source1 match {
-      case xml"""<double>$h<double>""" => h.as[Double]
+    source1.double match {
+      case xml"""<double>$h</double>""" => h.as[Double]
     }
   } returns 3.14159
 
   val `Match boolean` = test {
-    source1 match {
-      case xml"""<boolean>$h<boolean>""" => h.as[Boolean]
+    source1.boolean match {
+      case xml"""<boolean>$h</boolean>""" => h.as[Boolean]
     }
   } returns true
 }

--- a/xml-test/shared/src/test/scala/rapture/xml-test/tests.scala
+++ b/xml-test/shared/src/test/scala/rapture/xml-test/tests.scala
@@ -183,6 +183,11 @@ abstract class XmlTests(ast: XmlAst, parser: Parser[String, XmlAst]) extends Tes
     Xml(1648).toString
   } returns "xml\"\"\"1648\"\"\""
 
+  val `Extract top level xml elements` = test {
+    val fooXML = Xml(Foo("Joe", 10))
+    fooXML.alpha.as[String]
+  } returns "Joe"
+
   /*val `Serialize array` = test {
     Json(List(1, 2, 3)).toString
   } returns "123"

--- a/xml-test/shared/src/test/scala/rapture/xml-test/tests.scala
+++ b/xml-test/shared/src/test/scala/rapture/xml-test/tests.scala
@@ -19,7 +19,6 @@ package rapture.xml.test
 
 import rapture.core._
 import rapture.xml._
-import rapture.data.Parser
 import rapture.test._
 
 

--- a/xml/shared/src/main/scala/rapture/xml/ast.scala
+++ b/xml/shared/src/main/scala/rapture/xml/ast.scala
@@ -17,12 +17,44 @@
 
 package rapture.xml
 
-import rapture.core._
-import rapture.data._
-
 import scala.util._
 
-trait XmlAst extends DataAst {
+trait XmlAst {
+
+  /** Dereferences the named element within the JSON object. */
+  def dereferenceObject(obj: Any, element: String): Any =
+    getObject(obj)(element)
+
+  /** Returns at `Iterator[String]` over the names of the elements in the JSON object. */
+  def getKeys(obj: Any): Iterator[String] =
+    getObject(obj).keys.iterator
+
+  /** Gets the indexed element from the parsed JSON array. */
+  def dereferenceArray(array: Any, element: Int): Any =
+    getArray(array)(element)
+
+  /** Tests if the element represents an `Object` */
+  def isObject(any: Any): Boolean
+
+  /** Tests if the element represents an `Array` */
+  def isArray(any: Any): Boolean
+
+  def isNull(any: Any): Boolean
+
+  /** Extracts a JSON object as a `Map[String, Any]` from the parsed JSON. */
+  def getObject(obj: Any): Map[String, Any]
+
+  def getChildren(obj: Any): Seq[Any] = {
+    val m = getObject(obj)
+    getKeys(obj).to[List] map m
+  }
+
+  def fromObject(obj: Map[String, Any]): Any
+
+  /** Extracts a JSON array as a `Seq[Any]` from the parsed JSON. */
+  def getArray(array: Any): Seq[Any]
+
+  def fromArray(array: Seq[Any]): Any
 
   def isScalar(any: Any) = isString(any)
 
@@ -45,6 +77,8 @@ trait XmlAst extends DataAst {
   /** Tests if the element represents a `String` */
   def isString(any: Any): Boolean
 
+  val nullValue = ""
+
   /** Returns the DataType instance for the particular type. */
   def getType(any: Any): DataTypes.DataType =
     if (isString(any)) DataTypes.String
@@ -52,17 +86,33 @@ trait XmlAst extends DataAst {
     else if (isArray(any)) DataTypes.Array
     else throw MissingValueException()
 
-  def convert(v: Any, ast: DataAst): Any = {
-    val oldAst = ast.asInstanceOf[XmlAst]
-    if (oldAst.isString(v)) fromString(oldAst.getString(v))
-    else if (oldAst.isArray(v)) fromArray(oldAst.getArray(v).map(convert(_, oldAst)))
-    else if (oldAst.isObject(v)) fromObject(oldAst.getObject(v).mapValues(convert(_, oldAst)))
+  def convert(v: Any, ast: XmlAst): Any = {
+    if (ast.isString(v)) fromString(ast.getString(v))
+    else if (ast.isArray(v)) fromArray(ast.getArray(v).map(convert(_, ast)))
+    else if (ast.isObject(v)) fromObject(ast.getObject(v).mapValues(convert(_, ast)))
     else nullValue
   }
-
-  val nullValue = ""
 
   protected def typeTest(pf: PartialFunction[Any, Unit])(v: Any) = pf.isDefinedAt(v)
 }
 
-trait XmlBufferAst extends XmlAst with MutableDataAst
+object DataTypes {
+  sealed class DataType(val name: String)
+  case object Number extends DataType("number")
+  case object String extends DataType("string")
+  case object Null extends DataType("null")
+  case object Boolean extends DataType("boolean")
+  case object Array extends DataType("array")
+  case object Object extends DataType("object")
+  case object Scalar extends DataType("scalar")
+  case object Container extends DataType("container")
+  case object Any extends DataType("any")
+}
+
+
+trait XmlBufferAst extends XmlAst {
+  def setObjectValue(obj: Any, name: String, value: Any): Any
+  def setArrayValue(array: Any, index: Int, value: Any): Any
+  def removeObjectValue(obj: Any, name: String): Any
+  def addArrayValue(array: Any, value: Any): Any
+}

--- a/xml/shared/src/main/scala/rapture/xml/ast.scala
+++ b/xml/shared/src/main/scala/rapture/xml/ast.scala
@@ -21,15 +21,15 @@ import scala.util._
 
 trait XmlAst {
 
-  /** Dereferences the named element within the JSON object. */
+  /** Dereferences the named element within the XML object. */
   def dereferenceObject(obj: Any, element: String): Any =
     getObject(obj)(element)
 
-  /** Returns at `Iterator[String]` over the names of the elements in the JSON object. */
+  /** Returns at `Iterator[String]` over the names of the elements in the XML object. */
   def getKeys(obj: Any): Iterator[String] =
     getObject(obj).keys.iterator
 
-  /** Gets the indexed element from the parsed JSON array. */
+  /** Gets the indexed element from the parsed XML array. */
   def dereferenceArray(array: Any, element: Int): Any =
     getArray(array)(element)
 
@@ -41,7 +41,7 @@ trait XmlAst {
 
   def isNull(any: Any): Boolean
 
-  /** Extracts a JSON object as a `Map[String, Any]` from the parsed JSON. */
+  /** Extracts a XML object as a `Map[String, Any]` from the parsed XML. */
   def getObject(obj: Any): Map[String, Any]
 
   def getChildren(obj: Any): Seq[Any] = {
@@ -51,7 +51,7 @@ trait XmlAst {
 
   def fromObject(obj: Map[String, Any]): Any
 
-  /** Extracts a JSON array as a `Seq[Any]` from the parsed JSON. */
+  /** Extracts a XML array as a `Seq[Any]` from the parsed XML. */
   def getArray(array: Any): Seq[Any]
 
   def fromArray(array: Seq[Any]): Any

--- a/xml/shared/src/main/scala/rapture/xml/context.scala
+++ b/xml/shared/src/main/scala/rapture/xml/context.scala
@@ -19,9 +19,167 @@ package rapture.xml
 
 import rapture.base._
 import rapture.core._
-import rapture.data._
 
 import language.experimental.macros
+object ArrayMatchingConfig {
+  implicit val ignoreByDefault = new ArrayMatchingConfig { def checkLengths = false }
+}
+
+object ObjectMatchingConfig {
+  implicit val ignoreByDefault = new ObjectMatchingConfig { def checkSizes = false }
+}
+
+trait ArrayMatchingConfig { def checkLengths: Boolean }
+trait ObjectMatchingConfig { def checkSizes: Boolean }
+
+abstract class DataContextMacros[+Data <: DataType[Data, XmlAst], -AstType <: XmlAst] {
+
+  def parseSource(s: List[String], stringsUsed: List[Boolean]): Option[(Int, Int, String)]
+
+  def dataCompanion(c: BlackboxContext): c.Expr[DataCompanion[Data, AstType]]
+
+  def contextMacro(c: BlackboxContext)(exprs: c.Expr[ForcedConversion[Data]]*)(
+    parser: c.Expr[Parser[String, AstType]]): c.Expr[Data] = {
+    import c.universe._
+
+    c.prefix.tree match {
+      case Select(Apply(Apply(_, List(Apply(_, rawParts))), _), _) =>
+        val ys = rawParts.to[List]
+        val text = rawParts map { case lit @ Literal(Constant(part: String)) => part }
+
+        val listExprs = c.Expr[List[ForcedConversion[Data]]](q"_root_.scala.List(..${exprs.map(_.tree).to[List]})")
+
+        val stringsUsed: List[Boolean] = listExprs.tree match {
+          case Apply(_, bs) =>
+            bs.map {
+              case Apply(Apply(TypeApply(Select(_, nme), _), _), _) => nme.toString == "forceStringConversion"
+            }
+        }
+
+        parseSource(text, stringsUsed) foreach {
+          case (n, offset, msg) =>
+            val oldPos = ys(n).asInstanceOf[Literal].pos
+
+            val newPos = oldPos.withPoint(oldPos.start + offset)
+            c.error(newPos, msg)
+        }
+
+        val listParts = c.Expr[List[ForcedConversion[Data]]](q"_root_.scala.List(..$rawParts)")
+
+        val comp = dataCompanion(c)
+
+        reify {
+          val sb = new StringBuilder
+          val textParts = listParts.splice.iterator
+          val expressions: Iterator[ForcedConversion[_]] = listExprs.splice.iterator
+
+          sb.append(textParts.next())
+
+          while (textParts.hasNext) {
+            sb.append(
+              comp.splice.construct(MutableCell(expressions.next.value), Vector())(parser.splice.ast).toBareString)
+            sb.append(textParts.next)
+          }
+
+          comp.splice.construct(MutableCell(parser.splice.parse(sb.toString).get), Vector())(parser.splice.ast)
+        }
+    }
+  }
+}
+
+class DataContext[+Data <: DataType[Data, XmlAst], -AstType <: XmlAst](companion: DataCompanion[Data, AstType],
+                                                                         sc: StringContext) {
+
+  protected def uniqueNonSubstring(s: String) = {
+    var cur, m = 0
+    s foreach { c =>
+      cur = if (c == '_') cur + 1 else 0
+      m = m max cur
+    }
+    "_" * (m + 1)
+  }
+
+  def unapplySeq[D <: DataType[D, XmlAst]](data: D)(
+    implicit arrayMatching: ArrayMatchingConfig,
+    objectMatching: ObjectMatchingConfig,
+    parser: Parser[String, AstType]): Option[Seq[DataType[D, XmlAst]]] =
+    try {
+      val placeholder = uniqueNonSubstring(sc.parts.mkString)
+      val PlaceholderNumber = (placeholder + "([0-9]+)" + placeholder).r
+      val count = Iterator.from(0)
+      val txt = sc.parts.reduceLeft(_ + s""""${placeholder}${count.next()}${placeholder}" """ + _)
+
+      val paths: Array[Vector[Either[Int, String]]] =
+        Array.fill[Vector[Either[Int, String]]](sc.parts.length - 1)(Vector())
+
+      val arrayLengths = new collection.mutable.HashMap[Vector[Either[Int, String]], Int]
+      val objectSizes = new collection.mutable.HashMap[Vector[Either[Int, String]], Int]
+
+      def extract(any: Any, path: Vector[Either[Int, String]]): Unit = {
+        // FIXME: Avoid using isScalar if possible
+        if (parser.ast.isScalar(any)) {
+          val ext = data.$extract(path).as[Any]
+          if (data.$extract(path).as[Any] != any) throw new Exception("Value doesn't match (1)")
+        } else if (parser.ast.isObject(any)) {
+          val obj = parser.ast.getObject(any)
+          objectSizes(path) = obj.size
+          obj foreach {
+            case (k, v) =>
+              if (parser.ast.isString(v)) parser.ast.getString(v) match {
+                case str: CharSequence =>
+                  str match {
+                    case PlaceholderNumber(n) =>
+                      paths(n.toInt) = path :+ Right(k)
+                    case _ => extract(v, path :+ Right(k))
+                  }
+              } else extract(v, path :+ Right(k))
+          }
+        } else if (parser.ast.isArray(any)) {
+          val array = parser.ast.getArray(any)
+          if (arrayMatching.checkLengths) arrayLengths(path) = array.length
+          array.zipWithIndex foreach {
+            case (e, i) =>
+              if (parser.ast.isString(e)) parser.ast.getString(e) match {
+                case str: CharSequence =>
+                  str match {
+                    case PlaceholderNumber(n) =>
+                      paths(n.toInt) = path :+ Left(i)
+                    case _ => extract(e, path :+ Left(i))
+                  }
+              } else extract(e, path :+ Left(i))
+          }
+        } else throw new Exception("Value doesn't match (2)")
+      }
+
+      extract(parser.parse(txt).get, Vector())
+
+      // Using a ListBuffer to work around SI-8947
+      val extractsBuffer = new collection.mutable.ListBuffer[D]
+      paths foreach { p =>
+        extractsBuffer += data.$extract(p)
+      }
+      val extracts = extractsBuffer.toList
+      extracts.foreach(_.$normalize)
+      val matchedArrayLengths = arrayLengths.forall {
+        case (p, len) =>
+          parser.ast.getArray(data.$extract(p).$normalize).length == len
+      }
+
+      val matchedObjectSizes = objectSizes.forall {
+        case (p, s) =>
+          if (objectMatching.checkSizes) parser.ast.getObject(data.$extract(p).$normalize).size == s
+          else parser.ast.getObject(data.$extract(p).$normalize).size >= 0
+      }
+
+      if (extracts.exists(_.$root.value == null) || !matchedArrayLengths || !matchedObjectSizes)
+        None
+      else Some(extracts)
+    } catch {
+      case e: Exception =>
+        None
+    }
+}
+
 
 private[xml] object XmlDataMacros extends DataContextMacros[Xml, XmlAst] {
 

--- a/xml/shared/src/main/scala/rapture/xml/context.scala
+++ b/xml/shared/src/main/scala/rapture/xml/context.scala
@@ -105,9 +105,9 @@ class DataContext[+Data <: DataType[Data, XmlAst], -AstType <: XmlAst](companion
     parser: Parser[String, AstType]): Option[Seq[DataType[D, XmlAst]]] =
     try {
       val placeholder = uniqueNonSubstring(sc.parts.mkString)
-      val PlaceholderNumber = (placeholder + "([0-9]+)" + placeholder).r
+      val PlaceholderNumber = ("\""+placeholder + "([0-9]+)" + placeholder+"\"").r
       val count = Iterator.from(0)
-      val txt = sc.parts.reduceLeft(_ + s""""${placeholder}${count.next()}${placeholder}" """ + _)
+      val txt = sc.parts.reduceLeft(_ + s""""${placeholder}${count.next()}${placeholder}"""" + _)
 
       val paths: Array[Vector[Either[Int, String]]] =
         Array.fill[Vector[Either[Int, String]]](sc.parts.length - 1)(Vector())

--- a/xml/shared/src/main/scala/rapture/xml/data.scala
+++ b/xml/shared/src/main/scala/rapture/xml/data.scala
@@ -1,0 +1,368 @@
+/*
+  Rapture, version 2.0.0. Copyright 2010-2016 Jon Pretty, Propensive Ltd.
+
+  The primary distribution site is
+
+    http://rapture.io/
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+  compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License is
+  distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package rapture.xml
+
+import rapture.core._
+
+import scala.util.Try
+
+import language.dynamics
+
+@implicitNotFound("Cannot find an implicit Formatter for ${AstType} data.")
+trait Formatter[-AstType <: XmlAst] {
+  type Out
+  def format(any: Any): Out
+}
+
+object DataCompanion { object Empty }
+
+object serializedNames {
+  object inUnderscoreStyle {
+    def apply[V, D] = nameMapperImplicit[V, D]
+    implicit def nameMapperImplicit[V, D] = new NameMapper[V, D] {
+      def encode(name: String): String = name.flatMap {
+        case lower if lower.isLower => lower.toString
+        case upper if upper.isUpper => s"_$upper".toLowerCase
+        case other => other.toString
+      }
+
+      def decode(name: String): String = name.foldLeft(("", false)) {
+        case ((acc, _), '_') => (acc, true)
+        case ((acc, true), other) => (acc+other.toString.toUpperCase, false)
+        case ((acc, false), other) => (acc+other, false)
+      }._1
+    }
+  }
+  
+  object inDashedStyle {
+    def apply[V, D] = nameMapperImplicit[V, D]
+    implicit def nameMapperImplicit[V, D] = new NameMapper[V, D] {
+      def encode(name: String): String = name.flatMap {
+        case lower if lower.isLower => lower.toString
+        case upper if upper.isUpper => s"-$upper".toLowerCase
+        case other => other.toString
+      }
+
+      def decode(name: String): String = name.foldLeft(("", false)) {
+        case ((acc, _), '-') => (acc, true)
+        case ((acc, true), other) => (acc+other.toString.toUpperCase, false)
+        case ((acc, false), other) => (acc+other, false)
+      }._1
+    }
+  }
+  
+  object identical {
+    def apply[V, D] = nameMapperImplicit[V, D]
+    implicit def nameMapperImplicit[V, D] = new NameMapper[V, D] {
+      def encode(name: String): String = name
+      def decode(name: String): String = name
+    }
+  }
+}
+
+object NameMapper {
+  implicit def identityNameMapper[V, D]: NameMapper[V, D] = serializedNames.identical[V, D]
+}
+
+trait NameMapper[+Value, +Data] {
+  def encode(name: String): String
+  def decode(name: String): String
+}
+
+trait DataCompanion[+Type <: DataType[Type, XmlAst], -AstType <: XmlAst] {
+
+  type ParseMethodConstraint <: MethodConstraint
+
+  def empty(implicit ast: AstType) =
+    construct(MutableCell(ast.fromObject(Map())), Vector())
+
+  def construct(any: MutableCell, path: Vector[Either[Int, String]])(implicit ast: AstType): Type
+
+  def parse[Source: StringSerializer](s: Source)(implicit mode: Mode[ParseMethodConstraint],
+                                                 parser: Parser[Source, AstType]): mode.Wrap[Type, ParseException] =
+    mode wrap {
+      construct(try MutableCell(parser.parse(s).get)
+                catch {
+                  case e: NoSuchElementException => mode.exception(ParseException(String(s)))
+                },
+                Vector())(parser.ast)
+    }
+
+  def raw(value: Any)(implicit ast: AstType): Type =
+    construct(MutableCell(value), Vector())
+
+  def format[T <: DataType[T, AstType]](data: T)(implicit f: Formatter[_ <: AstType]): f.Out =
+    f.format(data.$normalize)
+
+}
+
+case class DynamicApplication[D](path: List[Either[Int, String]], application: ForcedConversion2[D])
+
+case class DynamicPath[D](path: List[Either[Int, String]]) extends Dynamic {
+  def self = selectDynamic("self")
+  def selectDynamic(v: String) = DynamicPath[D](Right(v) :: path)
+  def applyDynamic(v: String)(i: Int) = DynamicPath[D](Left(i) :: Right(v) :: path)
+  def apply(i: Int) = DynamicPath[D](Left(i) :: path)
+
+  def updateDynamic(p: String)(value: ForcedConversion2[D]) =
+    DynamicApplication(Right(p) :: path, value)
+
+  def update(i: Int, value: ForcedConversion2[D]) =
+    DynamicApplication(Left(i) :: path, value)
+}
+
+case class MutableCell(var value: Any)
+
+trait DynamicData[+T <: DynamicData[T, AstType], +AstType <: XmlAst] extends Dynamic {
+
+  /** Assumes the Json object wraps a `Map`, and extracts the element `key`. */
+  def selectDynamic(key: String): T = $deref(Right(key) +: $path)
+  
+  def self = selectDynamic("self")
+
+  //def applyDynamic(key: String)(i: Int = 0): T = $deref(Left(i) +: Right(key) +: $path)
+
+  def $deref($path: Vector[Either[Int, String]]): T
+  def $path: Vector[Either[Int, String]]
+
+}
+
+object DataType {
+
+  class DataClassOperations[T <: DataType[T, AstType], AstType <: XmlAst](dataType: T) {
+    def ++[S <: DataType[S, Rep] forSome { type Rep }](b: S): T = {
+      val ast = dataType.$ast
+
+      def merge(a: Any, b: Any): Any = {
+        if (ast.isObject(a) && ast.isObject(b)) {
+          ast.fromObject(ast.getKeys(b).foldLeft(ast.getObject(a)) {
+            case (as, k) =>
+              as + (k -> {
+                    if (as contains k) merge(as(k), ast.dereferenceObject(b, k)) else ast.dereferenceObject(b, k)
+                  })
+          })
+        } else if (ast.isArray(a) && ast.isArray(b)) ast.fromArray(ast.getArray(a) ++ ast.getArray(b))
+        else b
+      }
+
+      val left = dataType.$normalize
+      val right = if (ast != b.$ast) ast.convert(b.$normalize, b.$ast.asInstanceOf[XmlAst]) else b.$normalize
+
+      dataType.$wrap(merge(left, right), Vector())
+    }
+
+    def copy(pvs: (DynamicPath[T] => DynamicApplication[_ <: DataType[T, _ <: AstType]])*): T = {
+      dataType.$wrap(pvs.foldLeft(dataType.$normalize) {
+        case (cur, pv) =>
+          val dPath = pv(DynamicPath(Nil))
+          val ast = dataType.$ast
+
+          if (dPath.application.nothing) cur
+          else {
+
+            def nav(path: List[Either[Int, String]], dest: Any, v: Any): Any = path match {
+              case Nil =>
+                v
+
+              case Right(next) :: list =>
+                val d = try ast.dereferenceObject(dest, next)
+                catch { case e: Exception => ast.fromObject(Map()) }
+                val src = ast.getObject(if (ast.isObject(dest)) dest else Map())
+                ast.fromObject(src + ((next, nav(list, d, v))))
+
+              case Left(next) :: list =>
+                val d = try ast.dereferenceArray(dest, next)
+                catch { case e: Exception => ast.fromArray(List()) }
+                val src = if (ast.isArray(dest)) ast.getArray(dest) else Nil
+                ast.fromArray(src.padTo(next + 1, ast.fromObject(Map())).updated(next, nav(list, d, v)))
+            }
+
+            nav(dPath.path.reverse, cur, dPath.application.value)
+          }
+      })
+    }
+  }
+}
+
+trait DataType[+T <: DataType[T, AstType], +AstType <: XmlAst] {
+  val $root: MutableCell
+  implicit def $ast: AstType
+  def $path: Vector[Either[Int, String]]
+  def $normalize: Any = doNormalize(false)
+  def $wrap(any: Any, $path: Vector[Either[Int, String]] = Vector()): T
+  def $deref($path: Vector[Either[Int, String]] = Vector()): T
+  def $extract($path: Vector[Either[Int, String]]): T
+
+  def \(key: String): T = $deref(Right(key) +: $path)
+
+  def \\(key: String): T = $wrap($ast.fromArray(derefRecursive(key, $normalize)))
+
+  def toBareString: String
+
+  private def derefRecursive(key: String, any: Any): List[Any] =
+    if (!$ast.isObject(any)) Nil
+    else
+      $ast.getKeys(any).to[List].flatMap {
+        case k if k == key => List($ast.dereferenceObject(any, k))
+        case k => derefRecursive(key, $ast.dereferenceObject(any, k))
+      }
+
+  protected def doNormalize(orEmpty: Boolean): Any = {
+    yCombinator[(Any, Vector[Either[Int, String]]), Any] { fn =>
+      {
+        case (j, Vector()) => j: Any
+        case (j, t :+ e) =>
+          fn(({
+            if (e.bimap(x => $ast.isArray(j), x => $ast.isObject(j))) {
+              try e.bimap($ast.dereferenceArray(j, _), $ast.dereferenceObject(j, _))
+              catch {
+                case TypeMismatchException(exp, fnd) => throw TypeMismatchException(exp, fnd)
+                case exc: Exception =>
+                  if (orEmpty) DataCompanion.Empty
+                  else {
+                    e match {
+                      case Left(e) => throw MissingValueException(s"[$e]")
+                      case Right(e) => throw MissingValueException(e)
+                    }
+                  }
+              }
+            } else
+              throw TypeMismatchException(
+                  if ($ast.isArray(j)) DataTypes.Array else DataTypes.Object,
+                  e.bimap(l => DataTypes.Array, r => DataTypes.Object)
+              )
+          }, t))
+      }
+    }($root.value -> $path)
+  }
+
+  /** Assumes the Json object is wrapping a `T`, and casts (intelligently) to that type. */
+  def as[S](implicit ext: Extractor[S, T], mode: Mode[`Data#as`]): mode.Wrap[S, ext.Throws] =
+    ext.extract(this.asInstanceOf[T], $ast, mode)
+
+  def is[S](implicit ext: Extractor[S, T]): Boolean =
+    try {
+      ext.extract(this.asInstanceOf[T], $ast, modes.throwExceptions())
+      true
+    } catch {
+      case e: Exception => false
+    }
+
+  def apply(i: Int = 0): T = $deref(Left(i) +: $path)
+
+  override def equals(any: Any) =
+    try {
+      any match {
+        case any: DataType[_, _] => $normalize == any.$normalize
+        case _ => false
+      }
+    } catch { case e: Exception => false }
+
+  override def hashCode = $root.value.hashCode ^ 3271912
+
+}
+
+trait MutableDataType[+T <: DataType[T, AstType], AstType <: XmlBufferAst] extends DataType[T, AstType] {
+
+  def $updateParents(p: Vector[Either[Int, String]], newVal: Any): Unit =
+    p match {
+      case Vector() =>
+        $root.value = newVal
+      case Left(idx) +: init =>
+        val jb = $deref(init)
+        val newJb = $ast.setArrayValue(Try(jb.$normalize).getOrElse($ast.fromArray(Nil)), idx, newVal)
+
+        if (jb match {
+              case jb: AnyRef =>
+                newJb match {
+                  case newJb: AnyRef => jb ne newJb
+                  case _ => false
+                }
+              case jb => jb == newJb
+            }) $updateParents(init, newJb)
+      case Right(key) +: init =>
+        val jb = $deref(init)
+        val newJb = $ast.setObjectValue(Try(jb.$normalize).getOrElse($ast.fromObject(Map())), key, newVal)
+
+        if (jb match {
+              case jb: AnyRef =>
+                newJb match {
+                  case newJb: AnyRef => jb ne newJb
+                  case _ => false
+                }
+              case jb => jb == newJb
+            }) $updateParents(init, newJb)
+    }
+
+  /** Updates the element `key` of the JSON object with the value `v` */
+  def updateDynamic(key: String)(v: ForcedConversion2[T]): Unit =
+    if (!v.nothing)
+      $updateParents($path, $ast.setObjectValue(Try($normalize).getOrElse($ast.fromObject(Map())), key, v.value))
+
+  /** Updates the `i`th element of the JSON array with the value `v` */
+  def update[T2](i: Int, v: T2)(implicit ser: Serializer[T2, T]): Unit =
+    $updateParents($path, $ast.setArrayValue(Try($normalize).getOrElse($ast.fromArray(Nil)), i, ser.serialize(v)))
+
+  /** Removes the specified key from the JSON object */
+  def -=(k: String): Unit = $updateParents($path, $ast.removeObjectValue(doNormalize(true), k))
+
+  /** Adds the specified value to the JSON array */
+  def +=[T2](v: T2)(implicit ser: Serializer[T2, T]): Unit = {
+    val r = doNormalize(true)
+    val insert = if (r == DataCompanion.Empty) $ast.fromArray(Nil) else r
+    $updateParents($path, $ast.addArrayValue(insert, ser.serialize(v)))
+  }
+}
+
+trait `Data#as` extends MethodConstraint
+trait `Data#normalize` extends MethodConstraint
+
+object ForcedConversion2 extends ForcedConversion2_1 {
+  implicit def forceOptConversion[T, D](opt: Option[T])(implicit ser: Serializer[T, D]) =
+    opt.map(t => ForcedConversion2[D](ser.serialize(t), false)) getOrElse
+      ForcedConversion2[D](null, true)
+}
+
+trait ForcedConversion2_1 {
+  implicit def forceConversion[T, D](t: T)(implicit ser: Serializer[T, D]) =
+    ForcedConversion2[D](ser.serialize(t), false)
+}
+
+case class ForcedConversion2[-D](value: Any, nothing: Boolean)
+
+object ForcedConversion extends ForcedConversion_1 {
+  implicit def forceOptConversion[T, D](opt: Option[T])(implicit ser: Serializer[T, D]) =
+    opt.map(t => ForcedConversion[D](ser.serialize(t), false)) getOrElse
+      ForcedConversion[D](null, true)
+}
+
+trait ForcedConversion_1 extends ForcedConversion_2 {
+  implicit def forceConversion[T, D](t: T)(implicit ser: Serializer[T, D]) =
+    ForcedConversion[D](ser.serialize(t), false)
+}
+
+trait ForcedConversion_2 {
+  // The name of this method is significant for some additional checking done in the macro `contextMacro`.
+  implicit def forceStringConversion[D, T: StringSerializer](value: T)(implicit ser: Serializer[String, D]) =
+    ForcedConversion[D](ser.serialize(?[StringSerializer[T]].serialize(value)), false)
+}
+
+case class ForcedConversion[-D](value: Any, nothing: Boolean)
+
+case class ParseException(source: String, line: Option[Int] = None, column: Option[Int] = None)
+    extends Exception("Failed to parse source")

--- a/xml/shared/src/main/scala/rapture/xml/exceptions.scala
+++ b/xml/shared/src/main/scala/rapture/xml/exceptions.scala
@@ -2,12 +2,12 @@
   Rapture, version 2.0.0. Copyright 2010-2016 Jon Pretty, Propensive Ltd.
 
   The primary distribution site is
-  
+
     http://rapture.io/
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
   compliance with the License. You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software distributed under the License is
@@ -16,13 +16,14 @@
  */
 
 package rapture.xml
-import scala.language.implicitConversions
 
-object `package` {
+sealed abstract class DataGetException(msg: String) extends RuntimeException(msg)
 
-  implicit def xmlStringContext(sc: StringContext)(implicit parser: Parser[String, XmlAst]) =
-    new XmlStrings(sc)
+case class TypeMismatchException(found: DataTypes.DataType, expected: DataTypes.DataType)
+    extends DataGetException(s"type mismatch: Expected ${expected.name} but found ${found.name}")
 
-  implicit def xmlBufferStringContext(sc: StringContext)(implicit parser: Parser[String, XmlBufferAst]) =
-    new XmlBufferStrings(sc)
-}
+case class MissingValueException(name: String = "")
+    extends DataGetException(
+        if (name.isEmpty)
+          "missing value"
+        else s"missing value: $name")

--- a/xml/shared/src/main/scala/rapture/xml/extractors.scala
+++ b/xml/shared/src/main/scala/rapture/xml/extractors.scala
@@ -18,11 +18,148 @@
 package rapture.xml
 
 import rapture.core._
-import rapture.data._
 
 import scala.util._
 
 import language.higherKinds
+
+case class FilterException() extends Exception("value was removed by filter")
+case class NotEmptyException() extends Exception
+
+object GeneralExtractors {
+
+  def tryExtractor[Data <: DataType[Data, _ <: XmlAst], T](
+                                                             implicit ext: Extractor[T, Data]): Extractor[Try[T], Data] { type Throws = Nothing } =
+    new Extractor[Try[T], Data] {
+      type Throws = Nothing
+      def extract(any: Data, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Try[T], Throws] = mode.wrap {
+        try ext.extract(any.$wrap(any.$normalize), any.$ast, modes.returnTry())
+        catch {
+          case e: Exception => Failure(e)
+        }
+      }
+    }
+
+  def optionExtractor[Data <: DataType[Data, _ <: XmlAst], T](
+                                                                implicit ext: Extractor[T, Data]): Extractor[Option[T], Data] { type Throws = Nothing } = {
+
+    new Extractor[Option[T], Data] {
+      type Throws = Nothing
+      def extract(any: Data, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Option[T], Throws] =
+        mode.wrap {
+          try ext.extract(any.$wrap(any.$normalize), any.$ast, modes.returnOption())
+          catch {
+            case e: Exception => None
+          }
+        }
+    }
+  }
+
+  def noneExtractor[Data <: DataType[_, XmlAst]]
+  : Extractor[None.type, Data] { type Throws = DataGetException with NotEmptyException } =
+    new Extractor[None.type, Data] {
+      type Throws = DataGetException with NotEmptyException
+      def extract(value: Data, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[None.type, Throws] =
+        mode.wrap {
+          val v = value.$wrap(value.$normalize)
+          if (ast.isObject(v) && ast.getKeys(v).size == 0) None
+          else mode.exception[None.type, NotEmptyException](NotEmptyException())
+        }
+    }
+
+  def genSeqExtractor[T, Coll[_], Data <: DataType[Data, _ <: XmlAst]](
+                                                                         implicit cbf: scala.collection.generic.CanBuildFrom[Nothing, T, Coll[T]],
+                                                                         ext: Extractor[T, Data]): Extractor[Coll[T], Data] { type Throws = ext.Throws } = {
+
+    new Extractor[Coll[T], Data] {
+      type Throws = ext.Throws
+      def extract(value: Data, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Coll[T], Throws] =
+        mode.wrap {
+          mode.catching[DataGetException, Coll[T]] {
+            val v = value.$wrap(value.$normalize)
+            v.$ast
+              .getArray(v.$root.value)
+              .to[List]
+              .zipWithIndex
+              .map {
+                case (e, i) =>
+                  mode.unwrap(ext.safeExtract(v.$wrap(e), v.$ast, Some(Left(i)), mode), s"($i)")
+              }
+              .to[Coll]
+          }
+        }
+    }
+  }
+
+  def mapExtractor[K, T, Data <: DataType[Data, _ <: XmlAst]](
+                                                                implicit ext: Extractor[T, Data],
+                                                                ext2: StringParser[K]): Extractor[Map[K, T], Data] { type Throws = ext.Throws with ext2.Throws } =
+    new Extractor[Map[K, T], Data] {
+      type Throws = ext.Throws with ext2.Throws
+      def extract(value: Data, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Map[K, T], Throws] =
+        mode.wrap {
+          value.$ast.getObject(value.$normalize) map {
+            case (k, v) =>
+              mode.unwrap(ext2.parse(k, mode)) -> mode.unwrap(
+                ext.safeExtract(value.$wrap(v), value.$ast, Some(Right(k)), mode))
+          }
+        }
+    }
+}
+
+object Extractor {
+  implicit def anyExtractor[Data <: DataType[_, XmlAst]]: Extractor[Any, Data] { type Throws = Nothing } =
+    new Extractor[Any, Data] {
+      type Throws = Nothing
+      def extract(value: Data, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Any, Throws] =
+        mode.wrap(value.$normalize)
+    }
+}
+
+@implicitNotFound("cannot extract type ${T} from ${D}.")
+abstract class Extractor[T, -D] extends Functor[({ type L[x] = Extractor[x, D] })#L, T] { ext =>
+  type Throws <: Exception
+
+  def safeExtract(any: D,
+                  ast: XmlAst,
+                  prefix: Option[Either[Int, String]],
+                  mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, Throws] = mode.wrap {
+    try mode.unwrap(extract(any, ast, mode))
+    catch {
+      case e @ TypeMismatchException(_, _) => mode.exception(e)
+      case e @ MissingValueException(_) => mode.exception(e)
+    }
+  }
+
+  def extract(any: D, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, Throws]
+
+  def rawMap[T2](fn: (T, Mode[_ <: MethodConstraint]) => T2): Extractor[T2, D] = new Extractor[T2, D] {
+    def extract(any: D, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T2, Throws] =
+      mode.wrap(fn(mode.unwrap(ext.extract(any, ast, mode)), mode.generic))
+  }
+
+  def filter(pred: T => Boolean): Extractor[T, D] { type Throws = ext.Throws with FilterException } =
+    new Extractor[T, D] {
+      type Throws = ext.Throws with FilterException
+      def extract(any: D, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, Throws] = mode.wrap {
+        val result = mode.unwrap(ext.extract(any, ast, mode))
+        if (pred(result)) result else mode.exception[T, FilterException](FilterException())
+      }
+    }
+
+  def orElse[TS >: T, T2 <: TS, D2 <: D](
+                                          ext2: => Extractor[T2, D2]): Extractor[TS, D2] { type Throws = DataGetException } =
+    new Extractor[TS, D2] {
+      type Throws = DataGetException
+      def extract(any: D2, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[TS, Throws] = mode.wrap {
+        try mode.unwrap(ext.extract(any, ast, mode))
+        catch {
+          case e: Exception => mode.unwrap(ext2.extract(any, ast, mode))
+        }
+      }
+    }
+}
+
 
 private[xml] case class XmlCastExtractor[T](ast: XmlAst, dataType: DataTypes.DataType)
 
@@ -45,7 +182,7 @@ private[xml] trait Extractors extends Extractors_1 {
   implicit def xmlExtractor(implicit ast: XmlAst): Extractor[Xml, Xml] { type Throws = DataGetException } =
     new Extractor[Xml, Xml] {
       type Throws = DataGetException
-      def extract(any: Xml, dataAst: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Xml, DataGetException] =
+      def extract(any: Xml, dataAst: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[Xml, DataGetException] =
         mode.wrap(mode.catching[DataGetException, Xml](any.$wrap(any.$normalize)))
     }
 
@@ -60,7 +197,7 @@ private[xml] trait Extractors_1 {
     type Throws = DataGetException with ext.Throws
 
     def extract(any: Xml,
-                ast: DataAst,
+                ast: XmlAst,
                 mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, DataGetException with ext.Throws] = mode.wrap {
       val value: String = mode.catching[DataGetException, String](any.$ast.getString(any.$normalize))
       mode.unwrap(ext.parse(value, mode))
@@ -71,14 +208,14 @@ private[xml] trait Extractors_1 {
                                      ext: Extractor[T, Xml]): Extractor[T, XmlBuffer] { type Throws = ext.Throws } =
     new Extractor[T, XmlBuffer] {
       type Throws = ext.Throws
-      def extract(any: XmlBuffer, ast: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, ext.Throws] =
+      def extract(any: XmlBuffer, ast: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, ext.Throws] =
         ext.extract(Xml.construct(MutableCell(any.$root.value), Vector()), ast, mode)
     }
 
   implicit def xmlBufferToXmlExtractor(implicit ast: XmlBufferAst): Extractor[XmlBuffer, Xml] =
     new Extractor[XmlBuffer, Xml] {
       type Throws = DataGetException
-      def extract(any: Xml, dataAst: DataAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[XmlBuffer, Throws] =
+      def extract(any: Xml, dataAst: XmlAst, mode: Mode[_ <: MethodConstraint]): mode.Wrap[XmlBuffer, Throws] =
         mode.wrap(XmlBuffer.construct(MutableCell(XmlDataType.xmlSerializer.serialize(any)), Vector()))
     }
 

--- a/xml/shared/src/main/scala/rapture/xml/formatters.scala
+++ b/xml/shared/src/main/scala/rapture/xml/formatters.scala
@@ -18,7 +18,6 @@
 package rapture.xml
 
 import rapture.core._
-import rapture.data._
 
 object formatters {
   object compact {

--- a/xml/shared/src/main/scala/rapture/xml/macros.scala
+++ b/xml/shared/src/main/scala/rapture/xml/macros.scala
@@ -18,7 +18,6 @@
 package rapture.xml
 
 import rapture.base._
-import rapture.data._
 
 private[xml] object XmlMacros {
   def xmlExtractorMacro[T: c.WeakTypeTag, Th](c: WhiteboxContext): c.Expr[Extractor[T, Xml]] =
@@ -33,4 +32,245 @@ private[xml] object XmlMacros {
   def xmlBufferSerializerMacro[T: c.WeakTypeTag](c: WhiteboxContext)(
       ast: c.Expr[XmlBufferAst]): c.Expr[Serializer[T, XmlBuffer]] =
     Macros.serializerMacro[T, XmlBuffer](c)(ast)
+}
+
+object Macros {
+
+  // FIXME: Include enclosing position in the HashSet too
+  val emittedWarnings = new collection.mutable.HashSet[String]
+
+  // FIXME: Consider adding this check for knownDirectSubclasses to support sealed case classes
+  // def impl[T: c.WeakTypeTag](c: WhiteboxContext): c.Tree = {
+  //   import c.universe._
+  //   def subs = weakTypeOf[T].typeSymbol.asClass.knownDirectSubclasses
+  //   val subs1 = subs
+  //   println(subs1)
+  //   val global = c.universe.asInstanceOf[tools.nsc.Global]
+  //   def checkSubsPostTyper = if (subs1 != subs)
+  //     c.error(c.macroApplication.pos, "sealed descendents appears after macro exansion")
+  //     val dummyTypTree =
+  //     new global.TypeTreeWithDeferredRefCheck()(() => { checkSubsPostTyper ; global.TypeTree(global.NoType) }).asInstanceOf[TypTree]
+  //   q"type T = $dummyTypTree; ${subs1.size} : _root_.scala.Int"
+  // }
+  // def numChildren[T]: Int = macro impl[T]
+
+  def extractorMacro[T: c.WeakTypeTag, Data: c.WeakTypeTag, Th](
+                                                                 c: WhiteboxContext): c.Expr[Extractor[T, Data]] = {
+    import c.universe._
+    import compatibility._
+
+    val extractorType = typeOf[Extractor[_, _]].typeSymbol.asType.toTypeConstructor
+    val nameMapperType = typeOf[NameMapper[_, _]].typeSymbol.asType.toTypeConstructor
+
+    val implicitSearchFailures = collection.mutable.ListMap[String, List[String]]().withDefault(_ => Nil)
+
+    val extractionType = weakTypeOf[T].typeSymbol.asClass
+
+    if (weakTypeOf[T] <:< typeOf[AnyVal]) {
+      val param = paramLists(c)(declarations(c)(weakTypeOf[T]).collect {
+        case t: MethodSymbol => t.asMethod
+      }.find(_.isPrimaryConstructor).get).head.head
+
+      val paramType = param.typeSignature
+
+      val inferredExtractor =
+        c.inferImplicitValue(appliedType(extractorType, List(paramType, weakTypeOf[Data])), false, false)
+
+      c.Expr[Extractor[T, Data]](q"$inferredExtractor.map { new ${weakTypeOf[T]}(_) }")
+
+    }/* else if (extractionType.isSealed) {
+
+      val subclasses = extractionType.knownDirectSubclasses.to[List]
+      def tsort(todo: Map[Set[String], Symbol], done: List[Symbol] = Nil): List[Symbol] = if(todo.isEmpty) done else {
+        val move = todo.filter { case (key, v) => (todo - key).forall(!_._1.subsetOf(key)) }
+        tsort(todo -- move.map(_._1), move.map(_._2).to[List] ::: done)
+      }
+
+      val paramSets = subclasses.map { subclass =>
+        (declarations(c)(subclass.asType.toType).collect {
+          case m: MethodSymbol if m.isCaseAccessor => m.asMethod
+        }.map(_.name.decodedName.toString).to[Set], subclass)
+      }
+
+      val sortedExtractors = tsort(paramSets.toMap).map { subclass =>
+        val searchType = appliedType(extractorType, List(subclass.asType.toType, weakTypeOf[Data]))
+        c.inferImplicitValue(searchType, false, false)
+      }
+
+      val NothingType = weakTypeOf[Nothing]
+
+      val throwsType = sortedExtractors.last.tpe.member(typeName(c, "Throws")).typeSignature
+
+      val combinedExtractors = sortedExtractors.reduceLeft { (left, right) => q"$left.orElse($right)" }
+
+      c.Expr[Extractor[T, Data]](q"""
+        (new _root_.rapture.data.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def extract(data: ${weakTypeOf[Data]}, ast: _root_.rapture.data.DataAst, mode: _root_.rapture.core.Mode[_  <: _root_.rapture.core.MethodConstraint]): mode.Wrap[${weakTypeOf[
+          T]}, Throws] = mode.wrap { $combinedExtractors }
+        }).asInstanceOf[_root_.rapture.data.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          type Throws = ${throwsType}
+        }]
+      """)
+
+    }*/ else {
+
+      require(weakTypeOf[T].typeSymbol.asClass.isCaseClass)
+
+      val typeDeclaration = companion(c)(weakTypeOf[T].typeSymbol).typeSignature
+      val valueParameters = paramLists(c)(declaration(c)(typeDeclaration, termName(c, "apply")).asMethod)
+      val defaults = valueParameters.flatten.map(_.asTerm.isParamWithDefault).zipWithIndex.filter(_._1).map(_._2 + 1).to[Set]
+
+      // FIXME integrate these into a fold
+      var throwsTypes: Set[Type] = Set(typeOf[DataGetException])
+
+      val params = declarations(c)(weakTypeOf[T]).collect {
+        case m: MethodSymbol if m.isCaseAccessor => m.asMethod
+      }.zipWithIndex map {
+        case (p, idx) =>
+          val nameMappingImplicit = c.inferImplicitValue(appliedType(nameMapperType, List(weakTypeOf[T], weakTypeOf[Data])), false, false)
+          val deref = q"""data.selectDynamic($nameMappingImplicit.encode(${p.name.decodedName.toString}))"""
+
+          val NothingType = weakTypeOf[Nothing]
+
+          val inferredImplicit =
+            try c.inferImplicitValue(appliedType(extractorType, List(p.returnType, weakTypeOf[Data])), false, false)
+            catch {
+              case e: Exception =>
+                implicitSearchFailures(p.returnType.toString) ::= p.name.decodedName.toString
+                null
+            }
+
+          val t = try {
+            inferredImplicit.tpe.member(typeName(c, "Throws")).typeSignature match {
+              case NothingType => List()
+              case refinedType: RefinedType => refinedType.parents
+              case typ: Type => List(typ)
+              case _ => ???
+            }
+          } catch {
+            case e: Exception => List()
+          }
+
+          if(!defaults.contains(idx + 1)) throwsTypes ++= t
+
+          // Borrowed from Shapeless
+          def companionRef(tpe: Type): Tree = {
+            val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+            val gTpe = tpe.asInstanceOf[global.Type]
+            val pre = gTpe.prefix
+            val sym = gTpe.typeSymbol
+            val cSym = sym.companionSymbol
+            if (cSym != NoSymbol) global.gen.mkAttributedRef(pre, cSym).asInstanceOf[Tree]
+            else Ident(tpe.typeSymbol.name.toTermName)
+          }
+
+
+          if (defaults.contains(idx + 1)) q"""
+          mode.unwrap(try $deref.as($inferredImplicit, mode.generic) catch { case e: Exception => mode.wrap(${companionRef(weakTypeOf[T])}.${termName(
+            c, "apply$default$" + (idx + 1))}.asInstanceOf[${p.returnType}]) }, ${"." + p.name.decodedName})
+          """ else q"""
+          mode.unwrap($deref.as($inferredImplicit, mode.generic), ${"." + p.name.decodedName})
+        """
+      }
+
+      if (implicitSearchFailures.nonEmpty) {
+        val paramStrings = implicitSearchFailures map {
+          case (t, p1 :: Nil) =>
+            s"parameter `$p1' of type $t"
+          case (t, p1 :: ps) =>
+            s"parameters ${ps.map(v => s"`$v'").mkString(", ")} and `$p1' of type $t"
+          case (t, Nil) =>
+            ??? // Doesn't happen
+        }
+        val errorString = paramStrings.to[List].reverse match {
+          case t1 :: Nil => t1
+          case t1 :: ts => s"${ts.mkString(", ")} and $t1"
+          case Nil => ??? // Doesn't happen
+        }
+        val plural =
+          if (implicitSearchFailures.flatMap(_._2).size > 1)
+            s"${weakTypeOf[Data].typeSymbol.name} extractors"
+          else
+            s"a ${weakTypeOf[Data].typeSymbol.name} extractor"
+
+        val err = s"Could not generate a ${weakTypeOf[Data].typeSymbol.name} extractor for case " +
+          s"class ${weakTypeOf[T].typeSymbol.name} because $plural for $errorString could not " +
+          s"be found"
+
+        if (!emittedWarnings.contains(err)) {
+          emittedWarnings += err
+          c.warning(NoPosition, err)
+        }
+      }
+
+      require(implicitSearchFailures.isEmpty)
+
+      val construction = c.Expr[T](q"""new ${weakTypeOf[T]}(..$params)""")
+
+      c.Expr[Extractor[T, Data]](q"""
+        (new _root_.rapture.xml.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def extract(data: ${weakTypeOf[Data]}, ast: _root_.rapture.xml.XmlAst, mode: _root_.rapture.core.Mode[_  <: _root_.rapture.core.MethodConstraint]): mode.Wrap[${weakTypeOf[
+        T]}, Throws] = mode.wrap { ${construction} }
+        }).asInstanceOf[_root_.rapture.xml.Extractor[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          type Throws = ${normalize(c)(typeIntersection(c)(throwsTypes.to[List]))}
+        }]
+      """)
+    }
+  }
+
+  def serializerMacro[T: c.WeakTypeTag, Data: c.WeakTypeTag](c: WhiteboxContext)(
+    ast: c.Expr[XmlAst]): c.Expr[Serializer[T, Data]] = {
+    import c.universe._
+    import compatibility._
+
+    val tpe = weakTypeOf[T].typeSymbol.asClass
+    val nameMapperType = typeOf[NameMapper[_, _]].typeSymbol.asType.toTypeConstructor
+    val serializer = typeOf[Serializer[_, _]].typeSymbol.asType.toTypeConstructor
+
+    if (weakTypeOf[T] <:< typeOf[AnyVal]) {
+
+      val param = paramLists(c)(declarations(c)(weakTypeOf[T]).collect {
+        case t: MethodSymbol => t.asMethod
+      }.find(_.isPrimaryConstructor).get).head.head
+
+      val paramName = param.name.decodedName.toString
+      val paramType = param.typeSignature
+      val inferredSerializer =
+        c.inferImplicitValue(appliedType(serializer, List(paramType, weakTypeOf[Data])), false, false)
+
+      val newName = termName(c, freshName(c)("param$"))
+
+      c.Expr[Serializer[T, Data]](q"$inferredSerializer.contramap[${weakTypeOf[T]}](_.${termName(c, paramName)})")
+    } else {
+      if (tpe.isCaseClass) {
+        val params = declarations(c)(weakTypeOf[T]).collect {
+          case m: MethodSymbol if m.isCaseAccessor => m.asMethod
+        }.map { p =>
+          val imp = c.inferImplicitValue(appliedType(serializer, List(p.returnType, weakTypeOf[Data])), false, false)
+          val appliedSerializerType = appliedType(nameMapperType, List(weakTypeOf[T], weakTypeOf[Data]))
+          val nameMapperImplicit = c.inferImplicitValue(appliedSerializerType, false, false)
+          q"""($nameMapperImplicit.encode(${p.name.decodedName.toString}),
+              $imp.serialize(${termName(c, "t")}.${p}))"""
+        }
+
+        c.Expr[Serializer[T, Data]](q"""new _root_.rapture.xml.Serializer[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def serialize(t: ${weakTypeOf[T]}): _root_.scala.Any =
+            $ast.fromObject(_root_.scala.collection.immutable.Map(..$params).filterNot { v => $ast.isNull(v._2) })
+        }""")
+      } else if (tpe.isSealed) {
+        val cases = tpe.knownDirectSubclasses.to[List]
+        val caseClauses = cases.map { sc =>
+          val fullySpecifiedSerializer = appliedType(serializer, List(sc.asType.toType, weakTypeOf[Data]))
+          val caseSerializer = c.inferImplicitValue(fullySpecifiedSerializer, false, false)
+          val pattern = pq"v: ${sc.asClass}"
+          cq"${pattern} => $caseSerializer.serialize(v)"
+        }
+
+        c.Expr[Serializer[T, Data]](q"""new _root_.rapture.xml.Serializer[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
+          def serialize(t: ${weakTypeOf[T]}): _root_.scala.Any = t match { case ..$caseClauses }
+        }""")
+      } else throw new Exception()
+
+    }
+  }
 }

--- a/xml/shared/src/main/scala/rapture/xml/parser.scala
+++ b/xml/shared/src/main/scala/rapture/xml/parser.scala
@@ -1,0 +1,10 @@
+package rapture.xml
+
+import scala.annotation.implicitNotFound
+
+
+@implicitNotFound(msg = "Cannot find ${Ast} parser for values of type ${Source}")
+trait Parser[-Source, +Ast <: XmlAst] {
+  val ast: Ast
+  def parse(s: Source): Option[Any]
+}

--- a/xml/shared/src/main/scala/rapture/xml/serializers.scala
+++ b/xml/shared/src/main/scala/rapture/xml/serializers.scala
@@ -18,9 +18,22 @@
 package rapture.xml
 
 import rapture.core._
-import rapture.data._
-
 import language.higherKinds
+import scala.annotation.implicitNotFound
+
+
+@implicitNotFound(
+  "Cannot serialize type $"+"{T} to $"+"{D}. Please provide an implicit Serializer " +
+    "of type $"+"{T}.")
+trait Serializer[T, -D] { ser =>
+  def serialize(t: T): Any
+
+  def contramap[T2](fn: T2 => T) = new Serializer[T2, D] {
+    def serialize(t: T2): Any = ser.serialize(fn(t))
+  }
+
+}
+
 
 private[xml] case class DirectXmlSerializer[T](ast: XmlAst)
 

--- a/xml/shared/src/main/scala/rapture/xml/xml.scala
+++ b/xml/shared/src/main/scala/rapture/xml/xml.scala
@@ -18,7 +18,6 @@
 package rapture.xml
 
 import rapture.core._
-import rapture.data._
 
 import language.experimental.macros
 import scala.language.implicitConversions
@@ -102,7 +101,7 @@ object Xml extends XmlDataCompanion[Xml, XmlAst] with Xml_1 {
     new Extractor[T, XmlDataType[_, _ <: XmlAst]] {
       type Throws = DataGetException
       def extract(value: XmlDataType[_, _ <: XmlAst],
-                  ast2: DataAst,
+                  ast2: XmlAst,
                   mode: Mode[_ <: MethodConstraint]): mode.Wrap[T, DataGetException] =
         mode.wrap(ast2 match {
           case ast2: XmlAst =>


### PR DESCRIPTION
The main goal of this PR is to move JSON/XML modules to separate projects.

- [x] remove Data module dependency from JSON modules
- [x] remove Data module dependency from XML modules
- [ ] do cleanup
- [ ] fix most common XML/JSON bugs
     - [x] XML: https://github.com/propensive/rapture/issues/262
     - [x] XML: https://github.com/propensive/rapture/issues/263
     - [ ] XML: https://github.com/propensive/rapture/issues/264
     - [ ] XML: https://github.com/propensive/rapture/issues/253
     - [ ] XML: https://github.com/propensive/rapture/issues/250
     - [ ] XML: https://github.com/propensive/rapture/issues/247
     - [ ] XML/JSON: https://github.com/propensive/rapture/issues/238 
- [ ] add more XML/JSON unit tests
- [ ] switch to contextual
- [ ] Move JSON/XML modules to separate repos