### PR TITLE
Use ListMap instead of Map to avoid reordering

### DIFF
--- a/data/shared/src/main/scala/rapture/data/macros.scala
+++ b/data/shared/src/main/scala/rapture/data/macros.scala
@@ -226,7 +226,7 @@ object Macros {
 
         c.Expr[Serializer[T, Data]](q"""new _root_.rapture.data.Serializer[${weakTypeOf[T]}, ${weakTypeOf[Data]}] {
           def serialize(t: ${weakTypeOf[T]}): _root_.scala.Any =
-            $ast.fromObject(_root_.scala.collection.immutable.Map(..$params).filterNot { v => $ast.isNull(v._2) })
+            $ast.fromObject(_root_.scala.collection.immutable.ListMap(..$params).filterNot { v => $ast.isNull(v._2) })
         }""")
       } else if (tpe.isSealed) {
         val cases = tpe.knownDirectSubclasses.to[List]

--- a/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
+++ b/xml-stdlib/shared/src/main/scala/rapture/xml-stdlib/ast.scala
@@ -23,6 +23,7 @@ import rapture.data.DataTypes
 import rapture.data.TypeMismatchException
 import rapture.data.MissingValueException
 
+import scala.collection.immutable.ListMap
 import scala.xml._
 
 private[stdlib] object StdlibAst extends XmlBufferAst {
@@ -49,16 +50,15 @@ private[stdlib] object StdlibAst extends XmlBufferAst {
     case _ => throw TypeMismatchException(getType(string), DataTypes.String)
   }
 
-  def getObject(obj: Any): Map[String, Any] = obj match {
+  def getObject(obj: Any): ListMap[String, Any] = obj match {
     case n: Node =>
-      n.child.map { e =>
+      ListMap(n.child.map { e =>
         e.label -> e.child
-      }.toMap
+      }: _*)
     case n: NodeSeq =>
-      n.flatMap(_.child.map { e =>
+      ListMap(n.flatMap(_.child.map { e =>
           e.label -> e.child
-        })
-        .toMap
+        }): _*)
     case _ => throw TypeMismatchException(getType(obj), DataTypes.Object)
   }
 
@@ -78,7 +78,7 @@ private[stdlib] object StdlibAst extends XmlBufferAst {
     fromObject(getObject(obj).updated(name, value))
 
   def removeObjectValue(obj: Any, name: String): Any = obj match {
-    case obj: Map[_, _] => obj.asInstanceOf[Map[String, Any]] - name
+    case obj: ListMap[_, _] => obj.asInstanceOf[ListMap[String, Any]] - name
     case _ => throw TypeMismatchException(getType(obj), DataTypes.Object)
   }
 

--- a/xml/shared/src/main/scala/rapture/xml/ast.scala
+++ b/xml/shared/src/main/scala/rapture/xml/ast.scala
@@ -21,6 +21,7 @@ import rapture.core._
 import rapture.data._
 
 import scala.util._
+import scala.collection.immutable._
 
 trait XmlAst extends DataAst {
 


### PR DESCRIPTION
Case class parameters were being stored in a collection.immutable.Map,
which preserved their order for up to four elements, but after that the
order is based on hashes of the keys, and consequently the order appears
arbitrary.

This change replaces a few uses of `Map` with `ListMap`, notably in the
data macro and XML AST interface.

Quick review by @mielientiev.