### PR TITLE
Support for dictionaries

### DIFF
--- a/google-translate/shared/src/main/scala/rapture/google-translate/package.scala
+++ b/google-translate/shared/src/main/scala/rapture/google-translate/package.scala
@@ -101,8 +101,11 @@ object GoogleTranslate {
   import rapture.uri._
   import rapture.net._
   import rapture.io._
+  import rapture.data._
   import rapture.codec._, encodings.`UTF-8`._
   import rapture.json._, jsonBackends.jawn._
+
+  implicit val dict = Dictionary.define("translations", "data", "translatedText")
 
   def translate(key: String, text: String, from: String, to: String): String = {
     val out = uri"https://www.googleapis.com/language/translate/v2?q=$text&target=$to&format=text&source=$from&key=$key".slurp[Char]

--- a/json/shared/src/main/scala/rapture/json/json.scala
+++ b/json/shared/src/main/scala/rapture/json/json.scala
@@ -35,7 +35,7 @@ private[json] trait Json_1 extends Json_2 {
 }
 
 private[json] class DynamicWorkaround(json: Json) {
-  def self: Json = json.selectDynamic("self")
+  def self: Json = json.selectDynamic("self")(null)
 }
 
 trait `Json.parse` extends MethodConstraint
@@ -162,7 +162,7 @@ class Json(val $root: MutableCell, val $path: Vector[Either[Int, String]] = Vect
     else
       sp match {
         case Left(i) +: tail => apply(i).$extract(tail)
-        case Right(e) +: tail => selectDynamic(e).$extract(tail)
+        case Right(e) +: tail => selectDynamic(e)(null).$extract(tail)
       }
 
   def toBareString: String =
@@ -192,7 +192,7 @@ class JsonBuffer(val $root: MutableCell, val $path: Vector[Either[Int, String]] 
     else
       sp match {
         case Left(i) +: tail => apply(i).$extract(tail)
-        case Right(e) +: tail => selectDynamic(e).$extract(tail)
+        case Right(e) +: tail => selectDynamic(e)(null).$extract(tail)
       }
 
   def toBareString: String =

--- a/xml/shared/src/main/scala/rapture/xml/xml.scala
+++ b/xml/shared/src/main/scala/rapture/xml/xml.scala
@@ -36,7 +36,7 @@ private[xml] trait Xml_1 extends Xml_2 {
 }
 
 private[xml] class DynamicWorkaround(xml: Xml) {
-  def self: Xml = xml.selectDynamic("self")
+  def self: Xml = xml.selectDynamic("self")(null)
 }
 
 trait `Xml.parse` extends MethodConstraint
@@ -154,7 +154,7 @@ class Xml(val $root: MutableCell, val $path: Vector[Either[Int, String]] = Vecto
     else
       sp match {
         case Left(i) +: tail => apply(i).$extract(tail)
-        case Right(e) +: tail => selectDynamic(e).$extract(tail)
+        case Right(e) +: tail => selectDynamic(e)(null).$extract(tail)
       }
 
   override def toBareString =
@@ -182,7 +182,7 @@ class XmlBuffer(val $root: MutableCell, val $path: Vector[Either[Int, String]] =
     else
       sp match {
         case Left(i) +: tail => apply(i).$extract(tail)
-        case Right(e) +: tail => selectDynamic(e).$extract(tail)
+        case Right(e) +: tail => selectDynamic(e)(null).$extract(tail)
       }
 
   override def toBareString =


### PR DESCRIPTION
This will break a lot of code, as dynamic dereferencing is no longer the
default. To work around this, either import
rapture.data.dictionaries.dynamic._, or define a dictionary of keys,
like so:
```
implicit val dict = Dictionary.define("foo", "bar", "baz")
```
In this example, `foo`, `bar` and `baz` would be usable as lookup keys.