### PR TITLE
Double-backslash will now iterate into arrays

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ enablePlugins(GitBranchPrompt)
 lazy val buildSettings = Seq(
   organization := "com.propensive",
   scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.12.1", "2.11.8", "2.10.6")
+  crossScalaVersions := Seq("2.12.2", "2.11.8", "2.10.6")
 )
 
 lazy val commonSettings = Seq(


### PR DESCRIPTION
And single-backslash can take an integer instead of a string, and index
into an array.