### PR TITLE
Add refined type support to I18n constructor

### DIFF
--- a/i18n/shared/src/main/scala/rapture/i18n/i18n.scala
+++ b/i18n/shared/src/main/scala/rapture/i18n/i18n.scala
@@ -30,7 +30,7 @@ object Locale {
 }
 case class Locale[L <: Language: TypeTag]() {
   val typeTag: TypeTag[L] = implicitly[TypeTag[L]]
-  val name = typeTag.tpe.dealias.toString.split("\\.").last.toLowerCase
+  val name = typeTag.tpe.toString.split("\\.").last.toLowerCase
   def from[T, L2 <: L](i18n: I18n[T, L2]) = i18n(typeTag)
 
   def |[L2 <: Language](locale: Locale[L2]): LocaleParser[L with L2] =
@@ -63,8 +63,6 @@ object I18n {
 
   implicit def convertToType[T, L <: Language, L2 >: L <: Language: DefaultLanguage](i18n: I18n[T, L]): T =
     i18n.map(implicitly[DefaultLanguage[L2]].tag.tpe)
-
-  import scala.reflect.runtime.universe._
 
   class `I18n.apply`[L <: Language]() {
     def apply[T](value: T)(implicit tt: TypeTag[L]) = {

--- a/i18n/shared/src/main/scala/rapture/i18n/languages.scala
+++ b/i18n/shared/src/main/scala/rapture/i18n/languages.scala
@@ -17,8 +17,8 @@
 
 package rapture.i18n
 
-import scala.reflect._
 import annotation.unchecked._
+import scala.reflect.runtime.universe._
 
 object languages {
   object aa extends Locale[Aa]()
@@ -207,7 +207,7 @@ object languages {
   object zu extends Locale[Zu]()
 }
 
-case class DefaultLanguage[-L <: Language](tag: ClassTag[L @uncheckedVariance])
+case class DefaultLanguage[-L <: Language](tag: TypeTag[L @uncheckedVariance])
 
 trait Language
 final class Aa extends Language

--- a/i18n/shared/src/test/scala/rapture/i18n/tests.scala
+++ b/i18n/shared/src/test/scala/rapture/i18n/tests.scala
@@ -135,4 +135,9 @@ object I18nTests extends TestSuite {
     val msg = I18n[En with Fr]("biscuit")
     (msg[En], msg[Fr])
   } returns (("biscuit", "biscuit"))
+
+  val `Refined-type i18n can be combined like others` = test {
+    val msg = I18n[En with Fr]("biscuit") & de"german biscuit"
+    (msg[En], msg[Fr], msg[De])
+  } returns (("biscuit", "biscuit", "german biscuit"))
 }

--- a/i18n/shared/src/test/scala/rapture/i18n/tests.scala
+++ b/i18n/shared/src/test/scala/rapture/i18n/tests.scala
@@ -131,4 +131,8 @@ object I18nTests extends TestSuite {
     msg: String
   } returns "Bonjour"
 
+  val `Get both parent languages from a refined-type i18n` = test {
+    val msg = I18n[En with Fr]("biscuit")
+    (msg[En], msg[Fr])
+  } returns (("biscuit", "biscuit"))
 }


### PR DESCRIPTION
This supports the #274 by replacing usages of `ClassTag[_]` with `TypeTag[_]` which allows us to get the parents of the type, in the case of a refined `Lang` type such as `En with Fr with De`.  For example, see this:

```scala
  val `Get both parent languages from a refined-type i18n` = test {
    val msg = I18n[En with Fr]("biscuit")
    (msg[En], msg[Fr])
  } returns (("biscuit", "biscuit"))
```